### PR TITLE
Limit for timer event

### DIFF
--- a/distribution/index.html
+++ b/distribution/index.html
@@ -1948,6 +1948,9 @@ let core = {
 									let t = this.eventqueue[0].type;
 									let e = this.eventqueue[0].event;
 									this.eventqueue.splice(0, 1);
+									// this allows another timer event to be enqueued,
+									// while the timer event is executed
+									if (t == "timer") this.timerEventEnqueued = false;
 									if (this.eventhandler.hasOwnProperty(t))
 									{
 										let handler = this.eventhandler[t];
@@ -7187,7 +7190,10 @@ module.Interpreter = function(program)
 					}
 				}
 			}
-			if (this.background) this.enqueueEvent("timer", {"type": this.program.types[module.typeid_null], "value": {"b": null}});
+			if (this.background && !this.timerEventEnqueued)
+			{
+				this.timerEventEnqueued = this.enqueueEvent("timer", {"type": this.program.types[module.typeid_null], "value": {"b": null}});
+			}
 		}
 
 		let context = this;
@@ -7447,11 +7453,16 @@ module.Interpreter = function(program)
 	{
 		this.stop = true;
 	};
+	
+	// event limits
+	this.timerEventEnqueued = false;
 
 	// queue an event
+	// returns true when event got enqueued, false otherwise
 	this.enqueueEvent = function(type, event)
 	{
 		if (this.eventmode) this.eventqueue.push({"type": type, "event": event});
+		return this.eventmode;
 	};
 
 	// define an event handler - there can only be one :)
@@ -16406,6 +16417,9 @@ if (doc) doc.children.push({
 			<code class="code">setEventHandler</code> with
 			<code class="code">handler = null</code> removes the handler for
 			the given event type.
+			
+			When events take more than 20 milliseconds to complete,
+			the &quot;timer&quot; event only gets called once for this timespan.
 		</td></tr>
 		<tr><th>enterEventMode</th><td>
 			The <code class="code">function enterEventMode()</code> puts the

--- a/source/def-stdlib.js
+++ b/source/def-stdlib.js
@@ -165,6 +165,9 @@ if (doc) doc.children.push({
 			<code class="code">setEventHandler</code> with
 			<code class="code">handler = null</code> removes the handler for
 			the given event type.
+			
+			When events take more than 20 milliseconds to complete,
+			the &quot;timer&quot; event only gets called once for this timespan.
 		</td></tr>
 		<tr><th>enterEventMode</th><td>
 			The <code class="code">function enterEventMode()</code> puts the

--- a/source/tscript.js
+++ b/source/tscript.js
@@ -6817,8 +6817,7 @@ module.Interpreter = function(program)
 			}
 			if (this.background && !this.timerEventEnqueued)
 			{
-				this.enqueueEvent("timer", {"type": this.program.types[module.typeid_null], "value": {"b": null}});
-				this.timerEventEnqueued = true;
+				this.timerEventEnqueued = this.enqueueEvent("timer", {"type": this.program.types[module.typeid_null], "value": {"b": null}});
 			}
 		}
 
@@ -7084,9 +7083,11 @@ module.Interpreter = function(program)
 	this.timerEventEnqueued = false;
 
 	// queue an event
+	// returns true when event got enqueued, false otherwise
 	this.enqueueEvent = function(type, event)
 	{
 		if (this.eventmode) this.eventqueue.push({"type": type, "event": event});
+		return this.eventmode;
 	};
 
 	// define an event handler - there can only be one :)

--- a/source/tscript.js
+++ b/source/tscript.js
@@ -1573,6 +1573,9 @@ let core = {
 									let t = this.eventqueue[0].type;
 									let e = this.eventqueue[0].event;
 									this.eventqueue.splice(0, 1);
+									// this allows another timer event to be enqueued,
+									// while the timer event is executed
+									if (t == "timer") this.timerEventEnqueued = false;
 									if (this.eventhandler.hasOwnProperty(t))
 									{
 										let handler = this.eventhandler[t];
@@ -6812,7 +6815,11 @@ module.Interpreter = function(program)
 					}
 				}
 			}
-			if (this.background) this.enqueueEvent("timer", {"type": this.program.types[module.typeid_null], "value": {"b": null}});
+			if (this.background && !this.timerEventEnqueued)
+			{
+				this.enqueueEvent("timer", {"type": this.program.types[module.typeid_null], "value": {"b": null}});
+				this.timerEventEnqueued = true;
+			}
 		}
 
 		let context = this;
@@ -7072,6 +7079,9 @@ module.Interpreter = function(program)
 	{
 		this.stop = true;
 	};
+	
+	// event limits
+	this.timerEventEnqueued = false;
 
 	// queue an event
 	this.enqueueEvent = function(type, event)


### PR DESCRIPTION
When a timer event is already enqueued in the event queue, another timer event should not be enqueued again.