### PR TITLE
Add a delete button to file dialogs

### DIFF
--- a/source/ide.js
+++ b/source/ide.js
@@ -1544,12 +1544,13 @@ function fileDlg(title, filename, allowNewFilename, onOkay)
 	if (allowNewFilename)
 	{
 		name = tgui.createElement({
-				"parent": buttons,
+				"parent": dlg,
 				"type": "input",
-				"style": {"width": "calc(46vw - 240px)", "height": "20px", "background": "#fff"},
+				"style": {"position": "absolute", "width": "46vw", "left": "2vw", "height": "25px", "bottom": "40px"},
 				"text": filename,
 				"properties": {type:"text", placeholder:"Filename"}
 			});
+		list.style.height = "calc(70vh - 110px)";
 	}
 	let okay = tgui.createElement({
 			"parent": buttons,
@@ -1562,6 +1563,13 @@ function fileDlg(title, filename, allowNewFilename, onOkay)
 			"type": "button",
 			"style": {"width": "100px", "height": "25px", "margin-left": "10px"},
 			"text": "Cancel",
+		});
+	let deleteBtn = tgui.createElement({
+			"parent": buttons,
+			"type": "button",
+			"style": {"width": "100px", "height": "25px", "margin-left": "10px"},
+			"text": "Delete file",
+			"click": () => deleteFile(name.value),
 		});
 
 	// populate options
@@ -1582,17 +1590,7 @@ function fileDlg(title, filename, allowNewFilename, onOkay)
 				{
 					event.preventDefault();
 					event.stopPropagation();
-					let fn = name.value;
-					let index = files.indexOf(fn);
-					if (index >= 0)
-					{
-						if (confirm("Delete file \"" + fn + "\"\nAre you sure?"))
-						{
-							delete localStorage.removeItem("tscript.code." + fn);
-							files.splice(index, 1);
-							list.remove(index);
-						}
-					}
+					deleteFile(name.value);
 					return false;
 				}
 			});
@@ -1648,6 +1646,20 @@ function fileDlg(title, filename, allowNewFilename, onOkay)
 	tgui.startModal(dlg);
 	(allowNewFilename ? name : list).focus();
 	return dlg;
+
+	function deleteFile(filename)
+	{
+		let index = files.indexOf(filename);
+		if (index >= 0)
+		{
+			if (confirm("Delete file \"" + filename + "\"\nAre you sure?"))
+			{
+				localStorage.removeItem("tscript.code." + filename);
+				files.splice(index, 1);
+				list.remove(index);
+			}
+		}
+	}
 }
 
 module.create = function(container, options)


### PR DESCRIPTION
It's already possible to delete files by pressing the backspace or delete button in file dialogs. This adds an explicit button to the bottom. In save dialogs, where there is a text field for the file name, the field is moved above the buttons.

This was recently requested by someone in a Zoom call.

## Screenshots

![Load file dialog](https://user-images.githubusercontent.com/28811733/99553995-07209400-29bf-11eb-8f93-d640293ca12c.png)

![Save file dialog](https://user-images.githubusercontent.com/28811733/99554044-1273bf80-29bf-11eb-9709-4dfe9c795cf6.png)
