### PR TITLE
Improve webpack's settings for development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,26 +5,10 @@ const HtmlInlineScriptPlugin = require('html-inline-script-webpack-plugin');
 const HTMLInlineCSSWebpackPlugin = require("html-inline-css-webpack-plugin").default;
 
 
-module.exports = {
-  entry: ['./src/index.ts'],
-  module: {
-    rules: [
-      // compile typescript
-      {
-        test: /\.tsx?$/i,
-        use: 'ts-loader',
-      },
-      // bundle css
-      {
-        test: /\.css$/i,
-        use: [MiniCssExtractPlugin.loader, 'css-loader'],
-      }
-    ],
-  },
-  resolve: {
-    extensions: ['.tsx', '.ts', '.css', '.html'],
-  },
-  plugins: [
+module.exports = (_, options) => {
+  const isProd = options.mode === "production";
+
+  const plugins = [
     // handle css
     new MiniCssExtractPlugin(),
     // create webpage
@@ -32,12 +16,39 @@ module.exports = {
       inject: 'head',
       template: './src/index.html'
     }),
+  ];
+
+  if (isProd) {
     // inline
-    new HtmlInlineScriptPlugin(),
-    new HTMLInlineCSSWebpackPlugin(),
-  ],
-  output: {
-    path: path.resolve(__dirname, './distribution'),
-    filename: '_.js'
-  },
+    plugins.push(
+      isProd && new HtmlInlineScriptPlugin(),
+      isProd && new HTMLInlineCSSWebpackPlugin(),
+    );
+  }
+
+  return {
+    entry: ['./src/index.ts'],
+    module: {
+      rules: [
+        // compile typescript
+        {
+          test: /\.tsx?$/i,
+          use: 'ts-loader',
+        },
+        // bundle css
+        {
+          test: /\.css$/i,
+          use: [MiniCssExtractPlugin.loader, 'css-loader'],
+        }
+      ],
+    },
+    resolve: {
+      extensions: ['.tsx', '.ts', '.css', '.html'],
+    },
+    plugins,
+    output: {
+      path: path.resolve(__dirname, './distribution'),
+      filename: '[name].js'
+    },
+  }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = (_, options) => {
 
   return {
     entry: ['./src/index.ts'],
+    devtool: isProd ? false : "eval-cheap-module-source-map",
     module: {
       rules: [
         // compile typescript


### PR DESCRIPTION
Currently, the `dev`-script is supposed to watch in the background and rebuild when files change. However, the inlining plugins somehow don't re-emit their output, making the whole setup pointless. This is fixed by not using these plugins during development and emitting a separate javascript file instead.

This also enables us to use source maps during development! I chose the setting `eval-cheap-module-source-map`, because it shows the original source while supposedly being fast during rebuild ([see here](https://webpack.js.org/configuration/devtool/)), but that's still up for discussion.

<details>
<summary>Result in devtools</summary>

![Firefox devtools showing the original source](https://user-images.githubusercontent.com/28811733/106583920-e4c1ff80-6545-11eb-9e84-ba6c999b127b.png)

</details>
