### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Something isn't working correctly
+title: ''
+labels: bug
+assignees: ''
+---
+
+### Description  
+A clear description of what the bug is.
+
+### To Reproduce
+
+(if applicable) Example code:
+```
+# code...
+```
+
+Steps to reproduce the behavior and what was expected to happen instead:
+
+1. Go to `...`
+2. Click on `...`
+
+What should happen instead: `...`
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Describe the solution you'd like**
+A clear description of what you want to happen.
+
+* Describe problems this might solve
+* Describe the alternatives you've considered
+* Add examples or screenshots to add context


### PR DESCRIPTION
This adds issue templates for bug reports and feature requests. When creating an issue, users will see the option to use one of the templates or create a blank issue:

<img width="438" alt="Issue template options when creating a new issue" src="https://user-images.githubusercontent.com/28811733/107115413-d9841200-686c-11eb-80c6-43c8796b0b94.png">

Issues created using these templates will also be assigned the corresponding labels (`bug` for bug reports and `enhancement` for feature requests).