### PR TITLE
Add missing CodeMirror Addons

### DIFF
--- a/src/ide/codemirror-tscriptmode.ts
+++ b/src/ide/codemirror-tscriptmode.ts
@@ -1,6 +1,5 @@
-import { default as cm } from "codemirror";
+import CodeMirror from "codemirror";
 
-let CodeMirror: any = cm;
 export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, parserConfig)
 {
 	const keywords = {
@@ -105,7 +104,7 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 			var s = "";
 			var type:any = null;
 			var err = false;
-			let c = stream.next();
+			let c = stream.next()!;
 			if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_')
 			{
 				// parse an identifier or a keyword
@@ -113,7 +112,7 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 				s += c;
 				while (! stream.eol())
 				{
-					let c = stream.next();
+					let c = stream.next()!;
 					if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') s += c;
 					else { stream.backUp(1); break; }
 				}
@@ -127,7 +126,7 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 				s += c;
 				while (! stream.eol())
 				{
-					c = stream.next();
+					c = stream.next()!;
 					if (digits.indexOf(c) >= 0) s += c;
 					else { stream.backUp(1); break; }
 				}
@@ -135,7 +134,7 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 				{
 					if (! stream.eol())
 					{
-						c = stream.next();
+						c = stream.next()!;
 						if (c == '.')
 						{
 							// parse fractional part
@@ -144,12 +143,12 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 							if (stream.eol()) err = true;
 							else
 							{
-								c = stream.next();
+								c = stream.next()!;
 								if (digits.indexOf(c) >= 0) s += c;
 								else err = true;
 								while (! stream.eol())
 								{
-									c = stream.next();
+									c = stream.next()!;
 									if (digits.indexOf(c) >= 0) s += c;
 									else { stream.backUp(1); break; }
 								}
@@ -160,19 +159,19 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 
 					if (! stream.eol())
 					{
-						c = stream.next();
+						c = stream.next()!;
 						if (c == 'e' || c == 'E')
 						{
 							// parse exponent
 							s += c;
 							type = "number";
-							c = stream.next();
-							if (c == '+' || c == '-') { s += c; c = stream.next(); }
+							c = stream.next()!;
+							if (c == '+' || c == '-') { s += c; c = stream.next()!; }
 							if (digits.indexOf(c) < 0) err = true;
 							else if (c !== null) s += c;
 							while (! stream.eol())
 							{
-								c = stream.next();
+								c = stream.next()!;
 								if (digits.indexOf(c) >= 0) s += c;
 								else { stream.backUp(1); break; }
 							}
@@ -197,10 +196,10 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 				while (true)
 				{
 					if (stream.eol()) { err = true; break; }
-					c = stream.next();
+					c = stream.next()!;
 					if (c == '\\')
 					{
-						c = stream.next();
+						c = stream.next()!;
 						if (c == 'r') c = '\r';
 						else if (c == 'n') c = '\n';
 						else if (c == 't') c = '\t';
@@ -216,7 +215,7 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 				s += c;
 				while (! stream.eol())
 				{
-					c = stream.next();
+					c = stream.next()!;
 					if (operators.indexOf(c) >= 0) s += c;
 					else { stream.backUp(1); break; }
 				}
@@ -229,7 +228,7 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 					let star = false;
 					while (! stream.eol())
 					{
-						c = stream.next();
+						c = stream.next()!;
 						if (c == '#')
 						{
 							if (star) return type;
@@ -268,4 +267,4 @@ export const cmtsmode = CodeMirror.defineMode("text/tscript", function(config, p
 		lineComment: "#",
 		fold: "brace"
 	};
-}) + 1;
+});

--- a/src/ide/ide.ts
+++ b/src/ide/ide.ts
@@ -7,12 +7,20 @@ import { Parser } from "../lang/parser";
 import { Interpreter } from "../lang/interpreter/interpreter";
 import { defaultOptions } from "../lang/helpers/options";
 import { createDefaultServices } from "../lang/interpreter/defaultService";
-import { default as cm } from "codemirror";
-import { cmtsmode } from './codemirror-tscriptmode';
 
+import CodeMirror from "codemirror";
 
-cmtsmode;// use the mode so it gets used somewhere
-let CodeMirror:any = cm; 
+// CodeMirror Addons
+import "codemirror/addon/selection/active-line";
+import "codemirror/addon/comment/comment";
+import "codemirror/addon/dialog/dialog";
+import "codemirror/addon/dialog/dialog.css";
+import "codemirror/addon/search/jump-to-line";
+import "codemirror/addon/search/search";
+import "codemirror/addon/search/searchcursor";
+import "codemirror/addon/edit/matchbrackets";
+import "codemirror/addon/edit/closebrackets";
+import "./codemirror-tscriptmode";
 
 ///////////////////////////////////////////////////////////
 // IDE for TScript development
@@ -2229,9 +2237,9 @@ export let ide = (function() {
 						"Ctrl-R": "replace",
 						"F3": "findNext",
 						"Shift-F3": "findPrev",
-						"Ctrl-Up": "scrollUp",
-						"Ctrl-Down": "scrollDown",
-						"Shift-Tab": "unindent",
+						"Ctrl-Up": "goDocEnd",
+						"Ctrl-Down": "goDocStart",
+						"Shift-Tab": "indentLess",
 					},
 			});
 		module.sourcecode.on("change", function(cm, changeObj)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = (_, options) => {
       ],
     },
     resolve: {
-      extensions: ['.tsx', '.ts', '.css', '.html'],
+      extensions: ['.tsx', '.ts', '.js', '.css', '.html'],
     },
     plugins,
     output: {


### PR DESCRIPTION
This adds back some CodeMirror addons that seem to have been overlooked in #57. There are three commands that I needed to change ([list of supported commands](https://codemirror.net/doc/manual.html#commands)):

https://github.com/TGlas/tscript/blob/06c45532b52748afbc75b3b71effd23f2311866a/src/ide/ide.ts#L2232-L2234

`unindent` is now simply `indentLess`, but I couldn't find anything on the other two. After trying what these shortcuts did in the ide before #57, they seem to be `goDocStart` and `goDocEnd`.

Also, all files are now importing CodeMirror with correct typings (without casting it to `any`).

fixes #69