### PR TITLE
Move the IDE to the root directory of the deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,17 +38,16 @@ jobs:
         run: npm test
 
       # Deploy to GitHub Pages
-      - name: Commit distribution artifacts
+      - name: Prepare deployment
         run: |
-          git checkout --orphan dist
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git reset
-          git add -f ./distribution/index.html
-          git commit -m "Deploy site"
-      - name: Push changes
-        uses: ad-m/github-push-action@master
+          rm ./out/tscript.js
+          mkdir ./out/distribution
+          mv ./src/ide/redirect.html ./out/distribution/index.html
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
-          force: true
+          folder: ./out
+          single-commit: true
+          git-config-name: github-actions[bot]
+          git-config-email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 distribution/
+out/

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ LICENSE
 # copied from .gitignore
 node_modules/
 distribution/
+out/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ programming language.
 
 TScript comes as a single html file. It does not require installation.
 Simply open the file in a modern browser and you are ready to go.
-[Click here for a quick test.](https://tglas.github.io/tscript/distribution/)
+[Click here for a quick test.](https://tglas.github.io/tscript/)
 For more serious use it is recommended to store the page in your local
 file system &mdash; use "save link as" (or similar) from the context
 menu.
@@ -28,16 +28,16 @@ print("Hello World");
 For proper example code have a look at the [examples](https://github.com/TGlas/tscript/tree/master/examples)
 directory.
 
--   [turtle graphics: snowflake](https://tglas.github.io/tscript/distribution?run#https://raw.githubusercontent.com/TGlas/tscript/master/examples/snowflake.tscript)
--   [canvas graphics: game of life](https://tglas.github.io/tscript/distribution?run#https://raw.githubusercontent.com/TGlas/tscript/master/examples/gameoflife.tscript)
--   [canvas graphics: 3D cube](https://tglas.github.io/tscript/distribution?run#https://raw.githubusercontent.com/TGlas/tscript/master/examples/cube3D.tscript)
--   [audio sine wave](https://tglas.github.io/tscript/distribution?run#https://raw.githubusercontent.com/TGlas/tscript/master/examples/audio.tscript)
+-   [turtle graphics: snowflake](https://tglas.github.io/tscript/?run#https://raw.githubusercontent.com/TGlas/tscript/master/examples/snowflake.tscript)
+-   [canvas graphics: game of life](https://tglas.github.io/tscript/?run#https://raw.githubusercontent.com/TGlas/tscript/master/examples/gameoflife.tscript)
+-   [canvas graphics: 3D cube](https://tglas.github.io/tscript/?run#https://raw.githubusercontent.com/TGlas/tscript/master/examples/cube3D.tscript)
+-   [audio sine wave](https://tglas.github.io/tscript/?run#https://raw.githubusercontent.com/TGlas/tscript/master/examples/audio.tscript)
 
 ## Documentation
 
 The documentation is included in the IDE. It can be accessed with the
 button at the top right. It is also available
-[here.](https://tglas.github.io/tscript/distribution/index.html?doc)
+[here.](https://tglas.github.io/tscript/?doc)
 
 ## Bugs
 

--- a/src/ide/redirect.html
+++ b/src/ide/redirect.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>TScript IDE</title>
+	</head>
+	<body>
+		<h1>The IDE moved!</h1>
+		<p>You can find it <a id="link" href="../">here</a>.</p>
+		<script type="text/javascript">
+			"use strict";
+			var url = new URL(
+				"../" + location.search + location.hash,
+				location.href
+			);
+			document.getElementById("link").href = url.toString();
+			location.replace(url);
+		</script>
+	</body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = (_, options) => {
 		},
 		plugins,
 		output: {
-			path: path.resolve(__dirname, "./distribution"),
+			path: path.resolve(__dirname, "./out"),
 			filename: "[name].js",
 		},
 	};

--- a/webpack.interop.js
+++ b/webpack.interop.js
@@ -15,7 +15,7 @@ module.exports = {
 		extensions: [".ts"],
 	},
 	output: {
-		path: path.resolve(__dirname, "./distribution"),
+		path: path.resolve(__dirname, "./out"),
 		library: "TScript",
 		libraryTarget: "var",
 		filename: "tscript.js",


### PR DESCRIPTION
We had discussed before in #57 that it would be neat to have the IDE at `https://tglas.github.io/tscript` instead of `https://tglas.github.io/tscript/distribution`. Because we are in-between semesters, I think we can finally do the move.

Old bookmarks and URLs are still supported and redirected by `redirect.html`, which is moved to `distribution/index.html` during deployment. It redirects to the new URL **keeping all query and hash strings**.

I renamed the output directory from `distribution` to the more common `out`. We could also use `build` or something similar as you like. ~~(Attention: at first, git will notice old `distribution` directories because it's no longer in `.gitignore`)~~

In the deployment workflow, I use a different action that makes deployments of whole directorries easier. I have [tested it](https://github.com/Jartreg/tscript/runs/3766628510?check_suite_focus=true) but I don't have much experience with this action. I'm confident it will work well but that's something to look out for.