### PR TITLE
Fix tokenize throwing when no tokens are found

### DIFF
--- a/src/ide/search.ts
+++ b/src/ide/search.ts
@@ -27,8 +27,9 @@ let createSearchEngine = function () {
 	module.dictionary = {};
 
 	// Tokenize an input string into words, discard white space and rubbish.
-	module.tokenize = function (s) {
+	module.tokenize = function (s: string): string[] {
 		let words = s.toLowerCase().match(/[a-z0-9äöüß-]+\w+/g);
+		if (!words) return [];
 		let ret = new Array();
 		for (let i = 0; i < words.length; i++) {
 			let w = words[i];


### PR DESCRIPTION
The `tokenize` function inside `search.ts` may throw a `TypeError`. The error occurs because `words` is `null` if `String#match` doesn't find any tokens. This is fixed by returning an empty array if no tokens are found.

![a screenshot of the TypeError in the console](https://user-images.githubusercontent.com/28811733/136058978-b2fe6cd4-619d-4d13-9586-d23a12e8832f.png)
