### PR TITLE
Fix TypeError in dialogs without onHelp

### DIFF
--- a/src/ide/tgui.ts
+++ b/src/ide/tgui.ts
@@ -1334,7 +1334,7 @@ export let tgui = (function () {
 					event.preventDefault();
 					event.stopPropagation();
 				}
-				control.onHelp?.(event instanceof KeyboardEvent);
+				control.onHelp(event instanceof KeyboardEvent);
 				return false;
 			};
 		} else control.handleHelp = null;
@@ -1682,7 +1682,7 @@ export let tgui = (function () {
 					return dlg.handleClose(event);
 				}
 				if (event.key == "F1") {
-					return dlg.handleHelp(event);
+					return dlg.handleHelp?.(event);
 				} else if (
 					event.key == "Enter" &&
 					dlg.hasOwnProperty("enterConfirms") &&


### PR DESCRIPTION
Pressing <kbd>F1</kbd> in dialogs without a `onHelp` function causes a `TypeError` because the event handler tries to call a method that has been set to `null`. This is fixed by making the call optional.

![a screenshot of the TypeError in the console](https://user-images.githubusercontent.com/28811733/136059443-1a398086-44e4-4e2c-bee0-d7d4203f454d.png)
