### PR TITLE
use stricter path filter for showing search page

### DIFF
--- a/src/ide/index.ts
+++ b/src/ide/index.ts
@@ -111,7 +111,7 @@ class DocumentationPageController implements IPageController {
 
 	private showPage(params: URLSearchParams): void {
 		const docPage = params.get("doc") ?? "";
-		if (docPage === "search") {
+		if (docPage.startsWith("search/")) {
 			const searchQuery = params.get("q") ?? "";
 			const tokens = searchengine.tokenize(searchQuery);
 			doc.setpath("search/" + tokens.join("/"));


### PR DESCRIPTION
This pr prevents the user from bypassing the search engine tokenizer by setting the `doc` query parameter to a full search path like `search/word1/word2`. This is important because the code in https://github.com/TGlas/tscript/blob/9fa7bcc5d22c8e84ac2f32d7be955587e86c89b1/src/ide/doc.ts#L694 assumes that search keywords only contain letters and numbers.

This bug can lead to XSS: https://tglas.github.io/tscript/?doc=search/%3Cimg%20src=x%20onerror=alert(document.location)/%3E.