### PR TITLE
alert+confirm+prompt dialogs replaced with own modal dialogs

### DIFF
--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -379,8 +379,17 @@ export const evaluation = (function () {
 		interpreter.service.print = function (msg) {
 			output.push({ type: "print", value: msg });
 		};
-		interpreter.service.alert = function (msg) {
+		interpreter.service.alert = function (msg, reportValue) {
 			output.push({ type: "alert", value: msg });
+			reportValue();
+		};
+		interpreter.service.confirm = function (msg, reportValue) {
+			if (!inputs || inputs.length == 0) reportValue(false);
+			else reportValue(!!inputs.shift());
+		};
+		interpreter.service.prompt = function (msg, reportValue) {
+			if (!inputs || inputs.length == 0) reportValue("");
+			else reportValue(inputs.shift());
 		};
 		interpreter.service.message = function (
 			msg,
@@ -389,14 +398,6 @@ export const evaluation = (function () {
 			href: any = ""
 		) {
 			output.push({ type: "runtime error", message: msg, line: line });
-		};
-		interpreter.service.confirm = function (msg) {
-			if (!inputs || inputs.length == 0) return false;
-			else return !!inputs.shift();
-		};
-		interpreter.service.prompt = function (msg) {
-			if (!inputs || inputs.length == 0) return "";
-			else return inputs.shift();
 		};
 		interpreter.service.turtle.move = function (distance) {
 			let x0 = interpreter.service.turtle.x;

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -379,17 +379,23 @@ export const evaluation = (function () {
 		interpreter.service.print = function (msg) {
 			output.push({ type: "print", value: msg });
 		};
-		interpreter.service.alert = function (msg, reportValue) {
-			output.push({ type: "alert", value: msg });
-			reportValue();
+		interpreter.service.alert = function (msg) {
+			return new Promise((resolve, reject) => {
+				output.push({ type: "alert", value: msg });
+				resolve(null);
+			});
 		};
-		interpreter.service.confirm = function (msg, reportValue) {
-			if (!inputs || inputs.length == 0) reportValue(false);
-			else reportValue(!!inputs.shift());
+		interpreter.service.confirm = function (msg) {
+			return new Promise((resolve, reject) => {
+				if (!inputs || inputs.length == 0) resolve(false);
+				else resolve(!!inputs.shift());
+			});
 		};
-		interpreter.service.prompt = function (msg, reportValue) {
-			if (!inputs || inputs.length == 0) reportValue("");
-			else reportValue(inputs.shift());
+		interpreter.service.prompt = function (msg) {
+			return new Promise((resolve, reject) => {
+				if (!inputs || inputs.length == 0) resolve("");
+				else resolve(inputs.shift());
+			});
 		};
 		interpreter.service.message = function (
 			msg,

--- a/src/ide/css/ide.css
+++ b/src/ide/css/ide.css
@@ -198,6 +198,10 @@ button {
 	background-color: #aca;
 }
 
+.tgui-label.ide-state-dialog {
+	background-color: #cac;
+}
+
 .tgui-label.ide-state-stepping {
 	background-color: #8ee;
 }
@@ -231,4 +235,9 @@ button {
 	vertical-align: middle;
 	border: 1px solid #000;
 	display: none;
+}
+
+.ide-prompt-input {
+	width: 100%;
+	padding: 3px 6px;
 }

--- a/src/ide/css/ide.css
+++ b/src/ide/css/ide.css
@@ -198,10 +198,6 @@ button {
 	background-color: #aca;
 }
 
-.tgui-label.ide-state-dialog {
-	background-color: #cac;
-}
-
 .tgui-label.ide-state-stepping {
 	background-color: #8ee;
 }

--- a/src/ide/ide.ts
+++ b/src/ide/ide.ts
@@ -822,92 +822,98 @@ export let ide = (function () {
 				module.addMessage("print", msg);
 				module.interpreter.flush();
 			};
-			module.interpreter.service.alert = function (msg, reportValue) {
-				let dlg = tgui.msgBox({
-					title: "",
-					prompt: msg,
-					icon: tgui.msgBoxExclamation,
-					buttons: [{ text: "Close", isDefault: true }],
-					enterConfirms: true,
-					onClose: () => {
-						reportValue();
-						return false;
-					},
+			module.interpreter.service.alert = function (msg) {
+				return new Promise((resolve, reject) => {
+					let dlg = tgui.msgBox({
+						title: "",
+						prompt: msg,
+						icon: tgui.msgBoxExclamation,
+						buttons: [{ text: "Close", isDefault: true }],
+						enterConfirms: true,
+						onClose: () => {
+							resolve(null);
+							return false;
+						},
+					});
 				});
 			};
-			module.interpreter.service.confirm = function (msg, reportValue) {
-				let value = false;
-				let dlg = tgui.msgBox({
-					title: "Question",
-					prompt: msg,
-					icon: tgui.msgBoxQuestion,
-					buttons: [
-						{
-							text: "Yes",
-							isDefault: true,
-							onClick: () => {
-								value = true;
-								return false;
+			module.interpreter.service.confirm = function (msg) {
+				return new Promise((resolve, reject) => {
+					let value = false;
+					let dlg = tgui.msgBox({
+						title: "Question",
+						prompt: msg,
+						icon: tgui.msgBoxQuestion,
+						buttons: [
+							{
+								text: "Yes",
+								isDefault: true,
+								onClick: () => {
+									value = true;
+									return false;
+								},
 							},
-						},
-						{
-							text: "No",
-							isDefault: false,
-							onClick: () => {
-								value = false;
-								return false;
+							{
+								text: "No",
+								isDefault: false,
+								onClick: () => {
+									value = false;
+									return false;
+								},
 							},
+						],
+						enterConfirms: true,
+						onClose: () => {
+							resolve(value);
+							return false;
 						},
-					],
-					enterConfirms: true,
-					onClose: () => {
-						reportValue(value);
-						return false;
-					},
+					});
 				});
 			};
-			module.interpreter.service.prompt = function (msg, reportValue) {
-				let input = tgui.createElement({
-					type: "input",
-					classname: "ide-prompt-input",
-					properties: { type: "text" },
-				});
-				let value = null;
-				let dlg = tgui.createModal({
-					title: "Input",
-					scalesize: [0.2, 0.15],
-					minsize: [300, 150],
-					buttons: [
-						{
-							text: "Okay",
-							isDefault: true,
-							onClick: () => {
-								value = input.value;
-								return false;
+			module.interpreter.service.prompt = function (msg) {
+				return new Promise((resolve, reject) => {
+					let input = tgui.createElement({
+						type: "input",
+						classname: "ide-prompt-input",
+						properties: { type: "text" },
+					});
+					let value = null;
+					let dlg = tgui.createModal({
+						title: "Input",
+						scalesize: [0.2, 0.15],
+						minsize: [300, 150],
+						buttons: [
+							{
+								text: "Okay",
+								isDefault: true,
+								onClick: () => {
+									value = input.value;
+									return false;
+								},
 							},
-						},
-						{
-							text: "Cancel",
-							isDefault: false,
-							onClick: () => {
-								return false;
+							{
+								text: "Cancel",
+								isDefault: false,
+								onClick: () => {
+									return false;
+								},
 							},
+						],
+						enterConfirms: true,
+						onClose: () => {
+							resolve(value);
+							return false;
 						},
-					],
-					enterConfirms: true,
-					onClose: () => {
-						reportValue(value);
-						return false;
-					},
+					});
+					tgui.createElement({
+						type: "p",
+						parent: dlg.content,
+						text: msg,
+					});
+					dlg.content.appendChild(input);
+					tgui.startModal(dlg);
+					input.focus();
 				});
-				tgui.createElement({
-					type: "p",
-					parent: dlg.content,
-					text: msg,
-				});
-				dlg.content.appendChild(input);
-				tgui.startModal(dlg);
-				input.focus();
 			};
 			module.interpreter.service.message = function (
 				msg,

--- a/src/ide/ide.ts
+++ b/src/ide/ide.ts
@@ -2044,9 +2044,6 @@ export let ide = (function () {
 		module.programstate.waiting = function () {
 			this.setText("program is waiting").setStateCss("waiting");
 		};
-		module.programstate.dialog = function () {
-			this.setText("modal dialog").setStateCss("dialog");
-		};
 		module.programstate.stepping = function () {
 			this.setText("program is in stepping mode").setStateCss("stepping");
 		};

--- a/src/ide/ide.ts
+++ b/src/ide/ide.ts
@@ -622,6 +622,8 @@ export let ide = (function () {
 				else module.programstate.stepping();
 			} else if (module.interpreter.status === "waiting")
 				module.programstate.waiting();
+			else if (module.interpreter.status === "dialog")
+				module.programstate.dialog();
 			else if (module.interpreter.status === "error")
 				module.programstate.error();
 			else if (module.interpreter.status === "finished")
@@ -637,7 +639,8 @@ export let ide = (function () {
 			let should =
 				module.interpreter &&
 				(module.interpreter.status === "running" ||
-					module.interpreter.status === "waiting");
+					module.interpreter.status === "waiting" ||
+					module.interpreter.status === "dialog");
 			if (module.sourcecode.getOption("readOnly") != should) {
 				module.sourcecode.setOption("readOnly", should);
 				let ed: any = document.getElementsByClassName("CodeMirror");
@@ -819,14 +822,92 @@ export let ide = (function () {
 				module.addMessage("print", msg);
 				module.interpreter.flush();
 			};
-			module.interpreter.service.alert = function (msg) {
-				alert(msg);
+			module.interpreter.service.alert = function (msg, reportValue) {
+				let dlg = tgui.msgBox({
+					title: "",
+					prompt: msg,
+					icon: tgui.msgBoxExclamation,
+					buttons: [{ text: "Close", isDefault: true }],
+					enterConfirms: true,
+					onClose: () => {
+						reportValue();
+						return false;
+					},
+				});
 			};
-			module.interpreter.service.confirm = function (msg) {
-				return confirm(msg);
+			module.interpreter.service.confirm = function (msg, reportValue) {
+				let value = false;
+				let dlg = tgui.msgBox({
+					title: "Question",
+					prompt: msg,
+					icon: tgui.msgBoxQuestion,
+					buttons: [
+						{
+							text: "Yes",
+							isDefault: true,
+							onClick: () => {
+								value = true;
+								return false;
+							},
+						},
+						{
+							text: "No",
+							isDefault: false,
+							onClick: () => {
+								value = false;
+								return false;
+							},
+						},
+					],
+					enterConfirms: true,
+					onClose: () => {
+						reportValue(value);
+						return false;
+					},
+				});
 			};
-			module.interpreter.service.prompt = function (msg) {
-				return prompt(msg);
+			module.interpreter.service.prompt = function (msg, reportValue) {
+				let input = tgui.createElement({
+					type: "input",
+					classname: "ide-prompt-input",
+					properties: { type: "text" },
+				});
+				let value = null;
+				let dlg = tgui.createModal({
+					title: "Input",
+					scalesize: [0.2, 0.15],
+					minsize: [300, 150],
+					buttons: [
+						{
+							text: "Okay",
+							isDefault: true,
+							onClick: () => {
+								value = input.value;
+								return false;
+							},
+						},
+						{
+							text: "Cancel",
+							isDefault: false,
+							onClick: () => {
+								return false;
+							},
+						},
+					],
+					enterConfirms: true,
+					onClose: () => {
+						reportValue(value);
+						return false;
+					},
+				});
+				tgui.createElement({
+					type: "p",
+					parent: dlg.content,
+					text: msg,
+				});
+				dlg.content.appendChild(input);
+				tgui.startModal(dlg);
+				input.focus();
 			};
 			module.interpreter.service.message = function (
 				msg,
@@ -898,7 +979,8 @@ export let ide = (function () {
 		if (
 			!module.interpreter ||
 			(module.interpreter.status != "running" &&
-				module.interpreter.status != "waiting")
+				module.interpreter.status != "waiting" &&
+				module.interpreter.status != "dialog")
 		)
 			module.prepare_run();
 		if (!module.interpreter) return;
@@ -910,7 +992,8 @@ export let ide = (function () {
 		if (
 			!module.interpreter ||
 			(module.interpreter.status != "running" &&
-				module.interpreter.status != "waiting")
+				module.interpreter.status != "waiting" &&
+				module.interpreter.status != "dialog")
 		)
 			return;
 		module.interpreter.interrupt();
@@ -920,7 +1003,8 @@ export let ide = (function () {
 		if (
 			!module.interpreter ||
 			(module.interpreter.status != "running" &&
-				module.interpreter.status != "waiting")
+				module.interpreter.status != "waiting" &&
+				module.interpreter.status != "dialog")
 		)
 			module.prepare_run();
 		if (!module.interpreter) return;
@@ -932,7 +1016,8 @@ export let ide = (function () {
 		if (
 			!module.interpreter ||
 			(module.interpreter.status != "running" &&
-				module.interpreter.status != "waiting")
+				module.interpreter.status != "waiting" &&
+				module.interpreter.status != "dialog")
 		)
 			module.prepare_run();
 		if (!module.interpreter) return;
@@ -944,7 +1029,8 @@ export let ide = (function () {
 		if (
 			!module.interpreter ||
 			(module.interpreter.status != "running" &&
-				module.interpreter.status != "waiting")
+				module.interpreter.status != "waiting" &&
+				module.interpreter.status != "dialog")
 		)
 			module.prepare_run();
 		if (!module.interpreter) return;
@@ -957,7 +1043,8 @@ export let ide = (function () {
 		if (module.interpreter) {
 			if (
 				module.interpreter.status === "running" ||
-				module.interpreter.status === "waiting"
+				module.interpreter.status === "waiting" ||
+				module.interpreter.status === "dialog"
 			)
 				return;
 		}
@@ -1952,6 +2039,9 @@ export let ide = (function () {
 		module.programstate.waiting = function () {
 			this.setText("program is waiting").setStateCss("waiting");
 		};
+		module.programstate.dialog = function () {
+			this.setText("modal dialog").setStateCss("dialog");
+		};
 		module.programstate.stepping = function () {
 			this.setText("program is in stepping mode").setStateCss("stepping");
 		};
@@ -2292,7 +2382,8 @@ export let ide = (function () {
 				!module.interpreter ||
 				!module.interpreter.background ||
 				(module.interpreter.status != "running" &&
-					module.interpreter.status != "waiting")
+					module.interpreter.status != "waiting" &&
+					module.interpreter.status != "dialog")
 			)
 				return;
 			let e: any = {
@@ -2315,7 +2406,8 @@ export let ide = (function () {
 				!module.interpreter ||
 				!module.interpreter.background ||
 				(module.interpreter.status != "running" &&
-					module.interpreter.status != "waiting")
+					module.interpreter.status != "waiting" &&
+					module.interpreter.status != "dialog")
 			)
 				return;
 			let e: any = {
@@ -2338,7 +2430,8 @@ export let ide = (function () {
 				!module.interpreter ||
 				!module.interpreter.background ||
 				(module.interpreter.status != "running" &&
-					module.interpreter.status != "waiting")
+					module.interpreter.status != "waiting" &&
+					module.interpreter.status != "dialog")
 			)
 				return;
 			let e: any = {
@@ -2361,7 +2454,8 @@ export let ide = (function () {
 				!module.interpreter ||
 				!module.interpreter.background ||
 				(module.interpreter.status != "running" &&
-					module.interpreter.status != "waiting")
+					module.interpreter.status != "waiting" &&
+					module.interpreter.status != "dialog")
 			)
 				return;
 			let e = {
@@ -2375,7 +2469,8 @@ export let ide = (function () {
 				!module.interpreter ||
 				!module.interpreter.background ||
 				(module.interpreter.status != "running" &&
-					module.interpreter.status != "waiting")
+					module.interpreter.status != "waiting" &&
+					module.interpreter.status != "dialog")
 			)
 				return;
 			let e: any = {
@@ -2393,7 +2488,8 @@ export let ide = (function () {
 				!module.interpreter ||
 				!module.interpreter.background ||
 				(module.interpreter.status != "running" &&
-					module.interpreter.status != "waiting")
+					module.interpreter.status != "waiting" &&
+					module.interpreter.status != "dialog")
 			)
 				return;
 			let e: any = {

--- a/src/ide/ide.ts
+++ b/src/ide/ide.ts
@@ -623,7 +623,7 @@ export let ide = (function () {
 			} else if (module.interpreter.status === "waiting")
 				module.programstate.waiting();
 			else if (module.interpreter.status === "dialog")
-				module.programstate.dialog();
+				module.programstate.waiting();
 			else if (module.interpreter.status === "error")
 				module.programstate.error();
 			else if (module.interpreter.status === "finished")

--- a/src/ide/ide.ts
+++ b/src/ide/ide.ts
@@ -827,8 +827,7 @@ export let ide = (function () {
 					let dlg = tgui.msgBox({
 						title: "",
 						prompt: msg,
-						icon: tgui.msgBoxExclamation,
-						buttons: [{ text: "Close", isDefault: true }],
+						buttons: [{ text: "Okay", isDefault: true }],
 						enterConfirms: true,
 						onClose: () => {
 							resolve(null);

--- a/src/ide/index.ts
+++ b/src/ide/index.ts
@@ -111,7 +111,7 @@ class DocumentationPageController implements IPageController {
 
 	private showPage(params: URLSearchParams): void {
 		const docPage = params.get("doc") ?? "";
-		if (docPage.startsWith("search/")) {
+		if (docPage == "search" || docPage.startsWith("search/")) {
 			const searchQuery = params.get("q") ?? "";
 			const tokens = searchengine.tokenize(searchQuery);
 			doc.setpath("search/" + tokens.join("/"));

--- a/src/ide/index.ts
+++ b/src/ide/index.ts
@@ -111,7 +111,24 @@ class DocumentationPageController implements IPageController {
 
 	private showPage(params: URLSearchParams): void {
 		const docPage = params.get("doc") ?? "";
-		if (docPage == "search" || docPage.startsWith("search/")) {
+
+		if (docPage.startsWith("search/")) {
+			// This is not a url that anyone should link to,
+			// but it needs to be handled because paths starting with "search/"
+			// refer to search pages internally.
+
+			const tokens = docPage.slice(7).split("/");
+
+			// Since this is not a URL that should exist,
+			// redirect to the _correct_ one.
+			const redirectParams = new URLSearchParams({
+				doc: "search",
+				q: tokens.join(" "),
+			});
+			replaceUrl("?" + redirectParams.toString());
+
+			doc.setpath("search/" + tokens.join("/"));
+		} else if (docPage === "search") {
 			const searchQuery = params.get("q") ?? "";
 			const tokens = searchengine.tokenize(searchQuery);
 			doc.setpath("search/" + tokens.join("/"));

--- a/src/lang/interpreter/interpreter.ts
+++ b/src/lang/interpreter/interpreter.ts
@@ -9,7 +9,8 @@ export class Interpreter {
 	public stop = false; // request to stop the thread
 	public background = false; // is the thread responsible for running the program?
 	public halt: any = null; // function testing whether the thread should be halted
-	public status = ""; // program status: "running", "waiting", "error", "finished"
+	public status = ""; // program status: "running", "waiting", "dialog", "error", "finished"
+	public dialogResult: any = null; // result (typed value) returned by a modal alert/confirm/prompt dialog
 	public stack: Array<any> = []; // full state of the program
 	public breakpoints = {}; // breakpoints for debugging, keys are lines
 	public stepcounter = 0; // number of program steps already executed
@@ -47,6 +48,17 @@ export class Interpreter {
 		if (this.status === "waiting") {
 			let t = new Date().getTime();
 			if (t >= this.waittime) {
+				this.status = "running";
+				if (this.service.statechanged) this.service.statechanged(false);
+			}
+		}
+
+		if (this.status === "dialog") {
+			if (this.dialogResult) {
+				let frame = this.stack[this.stack.length - 1];
+				frame.temporaries[frame.temporaries.length - 1] =
+					this.dialogResult;
+				this.dialogResult = null;
 				this.status = "running";
 				if (this.service.statechanged) this.service.statechanged(false);
 			}

--- a/src/lang/tests/testRunner.ts
+++ b/src/lang/tests/testRunner.ts
@@ -79,27 +79,28 @@ export class TestRunner {
 		service.print = function (msg) {
 			result.push({ type: "print", message: msg });
 		};
-		service.alert = function (msg) {
+		service.alert = function (msg, reportValue) {
 			result.push({ type: "alert", message: msg });
+			reportValue();
 		};
-		(service.confirm = function (msg) {
+		service.confirm = function (msg, reportValue) {
 			result.push({ type: "confirm", message: msg });
 			let b = input.shift();
 			ErrorHelper.assert(
 				b === true || b === false,
 				"simulated user input is not a boolean"
 			);
-			return b;
-		}),
-			(service.prompt = function (msg) {
-				result.push({ type: "prompt", message: msg });
-				let s = input.shift();
-				ErrorHelper.assert(
-					typeof s == "string",
-					"simulated user input is not a string"
-				);
-				return s;
-			});
+			reportValue(b);
+		};
+		service.prompt = function (msg, reportValue) {
+			result.push({ type: "prompt", message: msg });
+			let s = input.shift();
+			ErrorHelper.assert(
+				typeof s == "string",
+				"simulated user input is not a string"
+			);
+			reportValue(s);
+		};
 		service.message = function (msg, line, ch, href) {
 			result.push({ type: "error", href: href });
 		};

--- a/src/lang/tests/testRunner.ts
+++ b/src/lang/tests/testRunner.ts
@@ -79,27 +79,33 @@ export class TestRunner {
 		service.print = function (msg) {
 			result.push({ type: "print", message: msg });
 		};
-		service.alert = function (msg, reportValue) {
-			result.push({ type: "alert", message: msg });
-			reportValue();
+		service.alert = function (msg) {
+			return new Promise((resolve, reject) => {
+				result.push({ type: "alert", message: msg });
+				resolve(null);
+			});
 		};
-		service.confirm = function (msg, reportValue) {
-			result.push({ type: "confirm", message: msg });
-			let b = input.shift();
-			ErrorHelper.assert(
-				b === true || b === false,
-				"simulated user input is not a boolean"
-			);
-			reportValue(b);
+		service.confirm = function (msg) {
+			return new Promise((resolve, reject) => {
+				result.push({ type: "confirm", message: msg });
+				let b = input.shift();
+				ErrorHelper.assert(
+					b === true || b === false,
+					"simulated user input is not a boolean"
+				);
+				resolve(b);
+			});
 		};
-		service.prompt = function (msg, reportValue) {
-			result.push({ type: "prompt", message: msg });
-			let s = input.shift();
-			ErrorHelper.assert(
-				typeof s == "string",
-				"simulated user input is not a string"
-			);
-			reportValue(s);
+		service.prompt = function (msg) {
+			return new Promise((resolve, reject) => {
+				result.push({ type: "prompt", message: msg });
+				let s = input.shift();
+				ErrorHelper.assert(
+					typeof s == "string",
+					"simulated user input is not a string"
+				);
+				resolve(s);
+			});
 		};
 		service.message = function (msg, line, ch, href) {
 			result.push({ type: "error", href: href });

--- a/src/lang/tscript-lib/core.ts
+++ b/src/lang/tscript-lib/core.ts
@@ -960,7 +960,7 @@ export const core = {
 			if (!this.service.documentation_mode && this.service.alert) {
 				this.status = "dialog";
 				this.dialogResult = null;
-				this.service.alert(s, () => {
+				this.service.alert(s).then(() => {
 					this.dialogResult = {
 						type: this.program.types[Typeid.typeid_null],
 						value: { b: null },
@@ -977,7 +977,7 @@ export const core = {
 			if (!this.service.documentation_mode && this.service.confirm) {
 				this.status = "dialog";
 				this.dialogResult = null;
-				this.service.confirm(s, (result) => {
+				this.service.confirm(s).then((result) => {
 					this.dialogResult = {
 						type: this.program.types[Typeid.typeid_boolean],
 						value: { b: result },
@@ -994,7 +994,7 @@ export const core = {
 			if (!this.service.documentation_mode && this.service.prompt) {
 				this.status = "dialog";
 				this.dialogResult = null;
-				this.service.prompt(s, (result) => {
+				this.service.prompt(s).then((result) => {
 					if (result === null)
 						this.dialogResult = {
 							type: this.program.types[Typeid.typeid_null],

--- a/src/lang/tscript-lib/core.ts
+++ b/src/lang/tscript-lib/core.ts
@@ -977,6 +977,7 @@ export const core = {
 			let s = TScript.toString.call(this, text);
 			if (!this.service.documentation_mode && this.service.confirm) {
 				this.status = "dialog";
+				this.service.statechanged?.(false);
 				this.dialogResult = null;
 				this.service.confirm(s).then((result) => {
 					this.dialogResult = {

--- a/src/lang/tscript-lib/core.ts
+++ b/src/lang/tscript-lib/core.ts
@@ -957,8 +957,16 @@ export const core = {
 		},
 		alert: function (text) {
 			let s = TScript.toString.call(this, text);
-			if (!this.service.documentation_mode && this.service.alert)
-				this.service.alert(s);
+			if (!this.service.documentation_mode && this.service.alert) {
+				this.status = "dialog";
+				this.dialogResult = null;
+				this.service.alert(s, () => {
+					this.dialogResult = {
+						type: this.program.types[Typeid.typeid_null],
+						value: { b: null },
+					};
+				});
+			}
 			return {
 				type: this.program.types[Typeid.typeid_null],
 				value: { b: null },
@@ -966,34 +974,43 @@ export const core = {
 		},
 		confirm: function (text) {
 			let s = TScript.toString.call(this, text);
-			let ret = false;
-			if (!this.service.documentation_mode && this.service.confirm)
-				ret = this.service.confirm(s);
+			if (!this.service.documentation_mode && this.service.confirm) {
+				this.status = "dialog";
+				this.dialogResult = null;
+				this.service.confirm(s, (result) => {
+					this.dialogResult = {
+						type: this.program.types[Typeid.typeid_boolean],
+						value: { b: result },
+					};
+				});
+			}
 			return {
 				type: this.program.types[Typeid.typeid_boolean],
-				value: { b: ret },
+				value: { b: false },
 			};
 		},
 		prompt: function (text) {
 			let s = TScript.toString.call(this, text);
-			let ret = null;
 			if (!this.service.documentation_mode && this.service.prompt) {
-				ret = this.service.prompt(s);
-				if (ret === null)
-					return {
-						type: this.program.types[Typeid.typeid_null],
-						value: { b: null },
-					};
-				else
-					return {
-						type: this.program.types[Typeid.typeid_string],
-						value: { b: ret },
-					};
-			} else
-				return {
-					type: this.program.types[Typeid.typeid_string],
-					value: { b: "" },
-				};
+				this.status = "dialog";
+				this.dialogResult = null;
+				this.service.prompt(s, (result) => {
+					if (result === null)
+						this.dialogResult = {
+							type: this.program.types[Typeid.typeid_null],
+							value: { b: null },
+						};
+					else
+						this.dialogResult = {
+							type: this.program.types[Typeid.typeid_string],
+							value: { b: result },
+						};
+				});
+			}
+			return {
+				type: this.program.types[Typeid.typeid_string],
+				value: { b: "" },
+			};
 		},
 		wait: function (milliseconds) {
 			if (!TScript.isNumeric(milliseconds.type))

--- a/src/lang/tscript-lib/core.ts
+++ b/src/lang/tscript-lib/core.ts
@@ -995,6 +995,7 @@ export const core = {
 			let s = TScript.toString.call(this, text);
 			if (!this.service.documentation_mode && this.service.prompt) {
 				this.status = "dialog";
+				this.service.statechanged?.(false);
 				this.dialogResult = null;
 				this.service.prompt(s).then((result) => {
 					if (result === null)

--- a/src/lang/tscript-lib/core.ts
+++ b/src/lang/tscript-lib/core.ts
@@ -959,6 +959,7 @@ export const core = {
 			let s = TScript.toString.call(this, text);
 			if (!this.service.documentation_mode && this.service.alert) {
 				this.status = "dialog";
+				this.service.statechanged?.(false);
 				this.dialogResult = null;
 				this.service.alert(s).then(() => {
 					this.dialogResult = {


### PR DESCRIPTION
This is my attempt to fix #106. The JS-native `alert`, `confirm` and `prompt` dialogs are replaced with tgui-based dialogs. According to my tests with various browser and OS combinations, this results in correct interpretation of the test program

    print(1);
    alert(2);
    print(3);

and similarly with `confirm` and `prompt`. The price is slightly increased complexity of the interpreter, which now has a "dialog" mode. That mode is similar to "waiting", but instead of continuing at a fixed time, it waits for the result from the modal dialog. Also, the alert/confirm/prompt services are now asynchronous: instead of returning a value they take a callback function as an additional argument.

I tested the following platforms:

- Firefox on Linux
- Chromium on Linux
- Chrome on Windows
- Opera on Windows

I'd appreciate further browser tests, and also a code review.
