### PR TITLE
Add redirect for doc urls starting with `search/`

### DIFF
--- a/src/ide/index.ts
+++ b/src/ide/index.ts
@@ -111,7 +111,24 @@ class DocumentationPageController implements IPageController {
 
 	private showPage(params: URLSearchParams): void {
 		const docPage = params.get("doc") ?? "";
-		if (docPage == "search" || docPage.startsWith("search/")) {
+
+		if (docPage.startsWith("search/")) {
+			// This is not a url that anyone should link to,
+			// but it needs to be handled because paths starting with "search/"
+			// refer to search pages internally.
+
+			const tokens = docPage.slice(7).split("/");
+
+			// Since this is not a URL that should exist,
+			// redirect to the _correct_ one.
+			const redirectParams = new URLSearchParams({
+				doc: "search",
+				q: tokens.join(" "),
+			});
+			replaceUrl("?" + redirectParams.toString());
+
+			doc.setpath("search/" + tokens.join("/"));
+		} else if (docPage === "search") {
 			const searchQuery = params.get("q") ?? "";
 			const tokens = searchengine.tokenize(searchQuery);
 			doc.setpath("search/" + tokens.join("/"));


### PR DESCRIPTION
If the `doc` url parameter is currently set to a path starting with `search/`, the search page is shown, but no query is passed to it unless there is a url parameter `q`.

`?doc=search/` should not show a search page in the first place, but because that's how the path works internally, it needs to be handled. As a compromise, this change redirects the user to the _proper_ search url with the given parameters.

Related to #108 