### PR TITLE
Other file storages

### DIFF
--- a/src/ide/css-dark/tgui.css
+++ b/src/ide/css-dark/tgui.css
@@ -200,3 +200,21 @@
 	background: #222;
 	color: #fff;
 }
+
+.dark-theme .tgui-modal-tab-button {
+	color: #aaa;
+}
+
+.dark-theme .tgui-modal-tab-button:hover {
+	color: #fff;
+	background: #282828;
+}
+
+.dark-theme .tgui-modal-tabs {
+	background: #222;
+}
+
+.dark-theme .tgui-modal-selected-tab-button {
+	color: #fff;
+	background: #333;
+}

--- a/src/ide/css/tgui.css
+++ b/src/ide/css/tgui.css
@@ -423,3 +423,36 @@
 	color: #000;
 	overflow: hidden;
 }
+
+.tgui-modal-tab-button {
+	background: #0000;
+	color: #444;
+	border-style: none;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	padding: 0 0 3px 0;
+	box-shadow: 0px 0px 3px #0003;
+}
+
+.tgui-modal-tab-button:hover {
+	color: #000;
+	background: #e4e4e4;
+	box-shadow: inset 0px -3px 3px -3px #0005, 0px 0px 3px #0005;
+}
+
+.tgui-modal-tabs {
+	background: #ddd;
+	border-style: none;
+	box-shadow: inset 0px -3px 3px -3px #0005;
+	overflow: hidden; /* hide bottom shadow */
+}
+
+.tgui-modal-selected-tab-button {
+	background: #eee;
+	color: #000;
+	border-style: none;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	padding: 0 0 3px 0;
+	box-shadow: 0px 0px 3px #0005;
+}

--- a/src/ide/gen-icons.ts
+++ b/src/ide/gen-icons.ts
@@ -148,6 +148,20 @@ const icons = (function () {
 		draw.line(20, 31, 20, 34);
 	});
 
+	icons.msgBoxInformation = svgIcon(40, 40, (draw: SVGDrawingContext) => {
+		draw.setStyle("stroke-width: 2; stroke: #04d; fill: #16f");
+		draw.circle(20, 20, 18.5);
+
+		draw.setStyle("stroke-width: 2; stroke: #fff; fill: none");
+		draw.line(20, 8, 20, 11);
+
+		draw.beginPath();
+		draw.moveTo(16, 15);
+		draw.lineTo(20, 15);
+		draw.lineTo(20, 32);
+		draw.endPath();
+	});
+
 	icons.msgBoxExclamation = svgIcon(40, 40, (draw: SVGDrawingContext) => {
 		draw.setStyle("stroke-width: 2; stroke: #a91; fill: #ec2");
 		draw.polygon([19, 2], [21, 2], [38, 36], [37, 38], [3, 38], [2, 36]);

--- a/src/ide/icons.ts
+++ b/src/ide/icons.ts
@@ -62,6 +62,12 @@ export const icons: { [id: string]: SVGIcon } = {
 		innerSVG:
 			'<circle cx="20" cy="20" r="18.5" style="stroke-width: 2; stroke: #04d; fill: #16f"/><path d="M 13,15 A 7,7 0 0 1 22.68,8.53 A 7,7 0 0 1 24.95,19.95 L 20 25 L 20 28" style="stroke-width: 2; stroke: #fff; fill: none"/><line x1="20" y1="31" x2="20" y2="34" style="stroke-width: 2; stroke: #fff; fill: none"/>',
 	},
+	msgBoxInformation: {
+		width: 40,
+		height: 40,
+		innerSVG:
+			'<circle cx="20" cy="20" r="18.5" style="stroke-width: 2; stroke: #04d; fill: #16f"/><line x1="20" y1="8" x2="20" y2="11" style="stroke-width: 2; stroke: #fff; fill: none"/><path d="M 16 15 L 20 15 L 20 32" style="stroke-width: 2; stroke: #fff; fill: none"/>',
+	},
 	msgBoxExclamation: {
 		width: 40,
 		height: 40,

--- a/src/ide/ide.ts
+++ b/src/ide/ide.ts
@@ -8,6 +8,8 @@ import { tgui } from "./tgui";
 import { toClipboard } from "./clipboard";
 import { tutorial } from "./tutorial";
 
+import { storage } from "./storage";
+
 import CodeMirror from "codemirror";
 
 // CodeMirror Addons
@@ -135,7 +137,8 @@ export let ide = (function () {
 
 	// document properties
 	(module.document = {
-		filename: "", // name in local storage, or empty string
+		file: storage.newFile(),
+		filename: "", // TODO remove this
 		dirty: false, // does the state differ from the last saved state?
 	}),
 		// current interpreter, non-null after successful parsing
@@ -1099,7 +1102,7 @@ export let ide = (function () {
 		}
 
 		// create a filename for the file download from the title
-		let title = module.document.filename;
+		let title = module.document.file.filename;
 		if (!title || title === "") title = "tscript-export";
 		let fn = title;
 		if (
@@ -1248,7 +1251,10 @@ export let ide = (function () {
 			clear();
 
 			module.editor_title.innerHTML = "Editor";
-			module.document.filename = "";
+			module.document.file = storage.newFile(
+				module.document.file.isDevice
+			);
+			module.document.filename = module.document.file.filename; // TODO remove later
 			module.sourcecode.setValue("");
 			module.sourcecode.getDoc().clearHistory();
 			module.document.dirty = false;
@@ -1260,54 +1266,50 @@ export let ide = (function () {
 
 	let cmd_load = function () {
 		confirmFileDiscard("Open document", () => {
-			fileDlg(
-				"Load file",
-				module.document.filename,
-				false,
-				"Load",
-				function (filename) {
+			storage.fileDialog(
+				module.document.file,
+				storage.DialogMode.OPEN,
+				function (file: storage.File) {
 					clear();
+					if (file.load) {
+						module.editor_title.innerHTML = "Editor &mdash; ";
+						tgui.createText(file.filename, module.editor_title);
+						module.document.file = file;
+						module.document.filename = file.filename; // TODO remove later
+						module.sourcecode.setValue(file.load());
+						module.sourcecode
+							.getDoc()
+							.setCursor({ line: 0, ch: 0 });
+						module.sourcecode.getDoc().clearHistory();
+						module.document.dirty = false;
 
-					module.editor_title.innerHTML = "Editor &mdash; ";
-					tgui.createText(filename, module.editor_title);
-					module.document.filename = filename;
-					module.sourcecode.setValue(
-						localStorage.getItem("tscript.code." + filename)
-					);
-					module.sourcecode.getDoc().setCursor({ line: 0, ch: 0 });
-					module.sourcecode.getDoc().clearHistory();
-					module.document.dirty = false;
-
-					updateControls();
-					module.sourcecode.focus();
+						updateControls();
+						module.sourcecode.focus();
+					}
 				}
 			);
 		});
 	};
 
 	let cmd_save = function () {
-		if (module.document.filename === "") {
+		if (module.document.file.save) {
+			// can save
+			module.document.file.save(module.sourcecode.getValue());
+			module.document.dirty = false;
+		} else {
 			cmd_save_as();
-			return;
 		}
-
-		localStorage.setItem(
-			"tscript.code." + module.document.filename,
-			module.sourcecode.getValue()
-		);
-		module.document.dirty = false;
 	};
 
 	let cmd_save_as = function () {
-		let dlg = fileDlg(
-			"Save file as ...",
-			module.document.filename,
-			true,
-			"Save",
-			function (filename) {
+		let dlg = storage.fileDialog(
+			module.document.file,
+			storage.DialogMode.SAVE,
+			function (file: storage.File) {
 				module.editor_title.innerHTML = "Editor &mdash; ";
-				tgui.createText(filename, module.editor_title);
-				module.document.filename = filename;
+				tgui.createText(file.filename, module.editor_title);
+				module.document.file = file;
+				module.document.filename = file.filename; // TODO remove later
 				cmd_save();
 				module.sourcecode.focus();
 			}
@@ -1697,262 +1699,6 @@ export let ide = (function () {
 		}
 
 		tgui.startModal(dlg);
-	}
-
-	function fileDlg(
-		title: string,
-		filename,
-		allowNewFilename: boolean,
-		confirmText: string,
-		onOkay
-	) {
-		// 10px horizontal spacing
-		//  7px vertical spacing
-		// populate array of existing files
-		let files = new Array();
-		for (let key in localStorage) {
-			if (key.substr(0, 13) === "tscript.code.")
-				files.push(key.substr(13));
-		}
-		files.sort();
-
-		// return true on failure, that is when the dialog should be kept open
-		let onFileConfirmation = function () {
-			let fn = name.value;
-			if (fn != "") {
-				if (allowNewFilename || files.indexOf(fn) >= 0) {
-					onOkay(fn);
-					return false; // close dialog
-				}
-			}
-			return true; // keep dialog open
-		};
-
-		// create dialog and its controls
-		let dlg = tgui.createModal({
-			title: title,
-			scalesize: [0.5, 0.7],
-			minsize: [440, 260],
-			buttons: [
-				{
-					text: confirmText,
-					isDefault: true,
-					onClick: onFileConfirmation,
-				},
-				{ text: "Cancel" },
-			],
-			enterConfirms: true,
-			contentstyle: {
-				display: "flex",
-				"flex-direction": "column",
-				"justify-content": "space-between",
-			},
-		});
-
-		let toolbar = tgui.createElement({
-			parent: dlg.content,
-			type: "div",
-			style: {
-				display: "flex",
-				"flex-direction": "row",
-				"justify-content": "space-between",
-				width: "100%",
-				height: "25px",
-				"margin-top": "7px",
-			},
-		});
-		// toolbar
-		{
-			let deleteBtn = tgui.createElement({
-				parent: toolbar,
-				type: "button",
-				style: {
-					width: "100px",
-					height: "100%",
-					"margin-right": "10px",
-				},
-				text: "Delete file",
-				click: () => deleteFile(name.value),
-				classname: "tgui-modal-button",
-			});
-
-			let importBtn = tgui.createElement({
-				parent: toolbar,
-				type: "button",
-				style: {
-					width: "100px",
-					height: "100%",
-					"margin-right": "10px",
-				},
-				text: "Import",
-				click: () => importFile(),
-				classname: "tgui-modal-button",
-			});
-
-			let exportBtn = tgui.createElement({
-				parent: toolbar,
-				type: "button",
-				style: {
-					width: "100px",
-					height: "100%",
-					"margin-right": "10px",
-				},
-				text: "Export",
-				click: () => exportFile(name.value),
-				classname: "tgui-modal-button",
-			});
-
-			// allow multiple selection: export selected
-			// TODO: allow to export all TScript files at once to a zip file
-			// TODO: allow to export whole TScript local storage
-
-			let status = tgui.createElement({
-				parent: toolbar,
-				type: "label",
-				style: {
-					flex: 1,
-					height: "100%",
-					"white-space": "nowrap",
-				},
-				text:
-					(files.length > 0 ? files.length : "No") +
-					" document" +
-					(files.length == 1 ? "" : "s"),
-				classname: "tgui-status-box",
-			});
-		}
-		// end toolbar
-
-		let list = tgui.createElement({
-			parent: dlg.content,
-			type: "select",
-			properties: { size: Math.max(2, files.length), multiple: false },
-			classname: "tgui-list-box",
-			style: {
-				flex: "auto",
-				//background: "#fff",
-				margin: "7px 0px",
-				overflow: "scroll",
-			},
-		});
-		let name = { value: filename };
-		if (allowNewFilename) {
-			name = tgui.createElement({
-				parent: dlg.content,
-				type: "input",
-				style: {
-					height: "25px",
-					//background: "#fff",
-					margin: "0 0px 7px 0px",
-				},
-				classname: "tgui-text-box",
-				text: filename,
-				properties: { type: "text", placeholder: "Filename" },
-			});
-		}
-
-		// populate options
-		for (let i = 0; i < files.length; i++) {
-			let option = new Option(files[i], files[i]);
-			list.options[i] = option;
-		}
-
-		// event handlers
-		list.addEventListener("change", function (event) {
-			if (event.target && event.target.value)
-				name.value = event.target.value;
-		});
-		list.addEventListener("keydown", function (event) {
-			if (event.key === "Backspace" || event.key === "Delete") {
-				event.preventDefault();
-				event.stopPropagation();
-				deleteFile(name.value);
-				return false;
-			}
-		});
-		list.addEventListener("dblclick", function (event) {
-			event.preventDefault();
-			event.stopPropagation();
-			if (!onFileConfirmation()) tgui.stopModal();
-			return false;
-		});
-
-		tgui.startModal(dlg);
-		(allowNewFilename ? name : list).focus();
-		return dlg;
-
-		function deleteFile(filename) {
-			let index = files.indexOf(filename);
-			if (index >= 0) {
-				let onDelete = () => {
-					localStorage.removeItem("tscript.code." + filename);
-					files.splice(index, 1);
-					list.remove(index);
-				};
-
-				tgui.msgBox({
-					title: "Delete file",
-					icon: tgui.msgBoxExclamation,
-					prompt: 'Delete file "' + filename + '"\nAre you sure?',
-					buttons: [
-						{ text: "Delete", isDefault: true, onClick: onDelete },
-						{ text: "Cancel" },
-					],
-				});
-			}
-		}
-
-		function download(filename, text, mime = "text/plain") {
-			var element = document.createElement("a");
-			element.setAttribute(
-				"href",
-				"data:" + mime + ";charset=utf-8," + encodeURIComponent(text)
-			);
-			element.setAttribute("download", filename);
-
-			element.style.display = "none";
-			document.body.appendChild(element);
-
-			element.click();
-
-			document.body.removeChild(element);
-		}
-
-		function exportFile(filename) {
-			let data = localStorage.getItem("tscript.code." + filename);
-			download(filename + ".tscript", data);
-		}
-
-		function importFile() {
-			let fileImport = document.createElement("input");
-			fileImport.type = "file";
-			fileImport.multiple = true;
-			fileImport.style.display = "none";
-			fileImport.accept = ".tscript";
-
-			fileImport.addEventListener("change", async (event: any) => {
-				if (event.target.files) {
-					for (let file of event.target.files) {
-						let filename = file.name.split(".tscript")[0];
-						if (files.includes(filename)) {
-							/*if(!confirm("Replace file \"" + filename + "\"\nAre you sure?"))
-							{
-								return;
-							}*/
-						}
-						let data = await file.text();
-						localStorage.setItem("tscript.code." + filename, data);
-						if (!files.includes(filename)) {
-							files.push(filename);
-							let option = new Option(filename, filename);
-							list.appendChild(option);
-						}
-					}
-				}
-			});
-
-			fileImport.click();
-		}
 	}
 
 	module.create = function (container, options) {

--- a/src/ide/storage.ts
+++ b/src/ide/storage.ts
@@ -1,0 +1,554 @@
+import { tgui } from "./tgui";
+
+export namespace storage {
+	export interface File {
+		isUnnamed: boolean;
+		filename: string;
+		isDevice: boolean;
+
+		save?(contents: string): void;
+		load?(): string;
+	}
+
+	export function newFile(isDevice: boolean = false): File {
+		return {
+			isUnnamed: true,
+			filename: "",
+			isDevice: isDevice,
+
+			load(): string {
+				return "";
+			},
+		};
+	}
+
+	export function localFile(filename: string): File {
+		return {
+			isUnnamed: false,
+			filename,
+			isDevice: false,
+
+			save(contents: string): void {
+				localStorage.setItem("tscript.code." + this.filename, contents);
+			},
+			load(): string {
+				return (
+					localStorage.getItem("tscript.code." + this.filename) ?? ""
+				);
+			},
+		};
+	}
+
+	// device file contents loaded previously
+	export function deviceFile(filename: string, contents: string): File {
+		let prv_contents = contents;
+		return {
+			isUnnamed: false,
+			filename,
+			isDevice: true,
+
+			save(contents: string): void {
+				prv_contents = contents;
+				saveDevice(this.filename, contents);
+			},
+			load(): string {
+				return prv_contents;
+			},
+		};
+	}
+
+	function saveDevice(
+		filename,
+		text,
+		mime = "text/plain"
+	) {
+		if (!filename.endsWith(".tscript")) filename += ".tscript";
+
+		var element = document.createElement("a");
+		element.setAttribute(
+			"href",
+			"data:" + mime + ";charset=utf-8," + encodeURIComponent(text)
+		);
+		element.setAttribute("download", filename);
+
+		element.style.display = "none";
+		document.body.appendChild(element);
+
+		element.click();
+
+		document.body.removeChild(element);
+	}
+
+	function loadDevice(
+		multiple: boolean,
+		handler: (filename: string, content: string) => void
+	) {
+		let fileImport = document.createElement("input");
+		fileImport.type = "file";
+		fileImport.multiple = multiple;
+		fileImport.style.display = "none";
+		fileImport.accept = ".tscript";
+
+		fileImport.addEventListener("change", async (event: any) => {
+			if (event.target.files) {
+				for (let file of event.target.files) {
+					let filename = file.name.split(".tscript")[0];
+					let data = await file.text();
+
+					handler(filename, data);
+				}
+			}
+		});
+
+		fileImport.click();
+	}
+
+	export enum DialogMode {
+		OPEN,
+		SAVE,
+	}
+
+	let dialogTitle = {
+		[DialogMode.OPEN]: "Load file",
+		[DialogMode.SAVE]: "Save file as ...",
+	};
+
+	let confirmText = {
+		[DialogMode.OPEN]: "Load",
+		[DialogMode.SAVE]: "Save",
+	};
+
+	export function fileDialog(
+		file: File,
+		mode: DialogMode,
+		onSelection: (file: File) => void
+	) {
+		let allowNewFilename = mode == DialogMode.SAVE;
+
+		// 10px horizontal spacing
+		//  7px vertical spacing
+		// populate array of existing files
+		let files = new Array();
+		for (let key in localStorage) {
+			if (key.substr(0, 13) === "tscript.code.")
+				files.push(key.substr(13));
+		}
+		files.sort();
+
+		let selectedTab = "local";
+
+		// return true on failure, that is when the dialog should be kept open
+		let onFileConfirmation = function () {
+			if (selectedTab == "device" && mode == DialogMode.OPEN) {
+				loadDeviceBtn.click();
+				return true;
+			} else {
+				let fn = name.value;
+				if (fn != "") {
+					if (allowNewFilename || files.indexOf(fn) >= 0) {
+						onSelection(
+							selectedTab == "device"
+								? deviceFile(fn, "")
+								: localFile(fn)
+						);
+						return false; // close dialog
+					}
+				}
+				return true; // keep dialog open
+			}
+		};
+
+		// create dialog and its controls
+		let dlg = tgui.createModal({
+			title: dialogTitle[mode],
+			scalesize: [0.5, 0.7],
+			minsize: [440, 260],
+			buttons: [
+				{
+					text: confirmText[mode],
+					isDefault: true,
+					onClick: onFileConfirmation,
+				},
+				{ text: "Cancel" },
+			],
+			enterConfirms: true,
+			contentstyle: {
+				display: "flex",
+				"flex-direction": "column",
+				"justify-content": "space-between",
+			},
+		});
+
+		let tabs = tgui.createElement({
+			parent: dlg.content,
+			type: "div",
+			style: {
+				display: "flex",
+				"flex-direction": "row",
+				"justify-content": "space-between",
+				width: "100%",
+				height: "43px",
+				"margin-top": "0px",
+				left: "0px",
+				right: "0px",
+				padding: "7px 0px 0px 10px",
+				position: "absolute",
+			},
+			classname: "tgui-modal-tabs",
+		});
+
+		let loadDeviceBtn;
+
+		let localBtn = tgui.createElement({
+			parent: tabs,
+			type: "button",
+			style: {
+				//flex: 1,
+				"margin-right": "10px",
+				width: "130px",
+			},
+			text: "Browser Storage",
+			click: selectLocal,
+			classname: "tgui-modal-selected-tab-button",
+		});
+
+		let deviceBtn = tgui.createElement({
+			parent: tabs,
+			type: "button",
+			style: {
+				//flex: 1,
+				//"margin-right": "10px",
+
+				width: "130px",
+				"margin-right": "auto",
+			},
+			text: "Device Storage",
+			click: selectDevice,
+			classname: "tgui-modal-tab-button",
+		});
+		function selectLocal() {
+			selectedTab = "local";
+			divLocalStorage.style.display = "flex";
+			localBtn.classList.replace(
+				"tgui-modal-tab-button",
+				"tgui-modal-selected-tab-button"
+			);
+			divDeviceStorage.style.display = "none";
+			deviceBtn.classList.replace(
+				"tgui-modal-selected-tab-button",
+				"tgui-modal-tab-button"
+			);
+		}
+
+		function selectDevice() {
+			selectedTab = "device";
+			divLocalStorage.style.display = "none";
+			localBtn.classList.replace(
+				"tgui-modal-selected-tab-button",
+				"tgui-modal-tab-button"
+			);
+			divDeviceStorage.style.display = "flex";
+			deviceBtn.classList.replace(
+				"tgui-modal-tab-button",
+				"tgui-modal-selected-tab-button"
+			);
+			//if(mode == DialogMode.OPEN) loadDeviceBtn.click();
+		}
+
+		let tabStyle = {
+			flex: "auto",
+			"flex-direction": "column",
+			"justify-content": "space-between",
+
+			width: "100%",
+			//height: allowNewFilename ? "calc(100% - 100px)": "calc(100% - 50px)",
+			//left: "0px",
+			//top: "50px",
+			//position: "absolute",
+			padding: "0px 0px",
+			"margin-top": "50px",
+		};
+
+		let divLocalStorage = tgui.createElement({
+			parent: dlg.content,
+			type: "div",
+			style: { ...tabStyle, display: "flex" },
+		});
+
+		var focusedElement;
+		let name = { value: file.filename }; // replaced by the text box
+		// local storage
+		{
+			let toolbar = tgui.createElement({
+				parent: divLocalStorage,
+				type: "div",
+				style: {
+					display: "flex",
+					"flex-direction": "row",
+					"justify-content": "space-between",
+					width: "100%",
+					height: "25px",
+				},
+			});
+
+			// toolbar
+			{
+				let deleteBtn = tgui.createElement({
+					parent: toolbar,
+					type: "button",
+					style: {
+						width: "100px",
+						height: "100%",
+						"margin-right": "10px",
+					},
+					text: "Delete file",
+					click: () => deleteFile(name.value),
+					classname: "tgui-modal-button",
+				});
+
+				let importBtn = tgui.createElement({
+					parent: toolbar,
+					type: "button",
+					style: {
+						width: "100px",
+						height: "100%",
+						"margin-right": "10px",
+					},
+					text: "Import",
+					click: () => importFile(),
+					classname: "tgui-modal-button",
+				});
+
+				let exportBtn = tgui.createElement({
+					parent: toolbar,
+					type: "button",
+					style: {
+						width: "100px",
+						height: "100%",
+						"margin-right": "10px",
+					},
+					text: "Export",
+					click: () => exportFile(name.value),
+					classname: "tgui-modal-button",
+				});
+
+				// allow multiple selection: export selected
+				// TODO: allow to export all TScript files at once to a zip file
+				// TODO: allow to export whole TScript local storage
+
+				let status = tgui.createElement({
+					parent: toolbar,
+					type: "label",
+					style: {
+						flex: 1,
+						height: "100%",
+						"white-space": "nowrap",
+					},
+					text:
+						(files.length > 0 ? files.length : "No") +
+						" document" +
+						(files.length == 1 ? "" : "s"),
+					classname: "tgui-status-box",
+				});
+			}
+			// end toolbar
+
+			let list = tgui.createElement({
+				parent: divLocalStorage,
+				type: "select",
+				properties: {
+					size: Math.max(2, files.length),
+					multiple: false,
+				},
+				classname: "tgui-list-box",
+				style: {
+					flex: "auto",
+					//background: "#fff",
+					margin: "7px 0px",
+					overflow: "scroll",
+				},
+			});
+
+			// populate options
+			for (let i = 0; i < files.length; i++) {
+				let option = new Option(files[i], files[i]);
+				list.options[i] = option;
+			}
+
+			// event handlers
+			list.addEventListener("change", function (event) {
+				if (event.target && event.target.value)
+					name.value = event.target.value;
+			});
+			list.addEventListener("keydown", function (event) {
+				if (event.key === "Backspace" || event.key === "Delete") {
+					event.preventDefault();
+					event.stopPropagation();
+					deleteFile(name.value);
+					return false;
+				}
+			});
+			list.addEventListener("dblclick", function (event) {
+				event.preventDefault();
+				event.stopPropagation();
+				if (!onFileConfirmation()) tgui.stopModal();
+				return false;
+			});
+
+			focusedElement = list;
+
+			function deleteFile(filename) {
+				let index = files.indexOf(filename);
+				if (index >= 0) {
+					let onDelete = () => {
+						localStorage.removeItem("tscript.code." + filename);
+						files.splice(index, 1);
+						list.remove(index);
+					};
+
+					tgui.msgBox({
+						title: "Delete file",
+						icon: tgui.msgBoxExclamation,
+						prompt: 'Delete file "' + filename + '"\nAre you sure?',
+						buttons: [
+							{
+								text: "Delete",
+								isDefault: true,
+								onClick: onDelete,
+							},
+							{ text: "Cancel" },
+						],
+					});
+				}
+			}
+
+			function exportFile(filename) {
+				let data = filename
+					? localStorage.getItem("tscript.code." + filename)
+					: null;
+				if (data == null) {
+					if (mode == DialogMode.SAVE) {
+						tgui.msgBox({
+							prompt: "There is no file to export. To save directly to the device switch to device storage or click on save current.",
+							icon: tgui.msgBoxInformation,
+							title: "Export File",
+							buttons: [
+								{
+									text: "Save Current",
+									onClick: () => selectDevice(),
+									isDefault: true,
+								},
+								{ text: "Cancel" },
+							],
+						});
+					}
+					return;
+				}
+
+				if (filename == file.filename && mode == DialogMode.SAVE) {
+					tgui.msgBox({
+						prompt: "This only exports the old file contents. To save directly to the device switch to device storage or click on save current.",
+						icon: tgui.msgBoxInformation,
+						title: "Export File",
+						buttons: [
+							{
+								text: "Export Old",
+								onClick: () =>
+									saveDevice(filename + ".tscript", data),
+								isDefault: true,
+							},
+							{
+								text: "Save Current",
+								onClick: () => selectDevice(),
+							},
+							{ text: "Cancel" },
+						],
+					});
+				} else {
+					saveDevice(filename + ".tscript", data);
+				}
+			}
+
+			function importFile() {
+				loadDevice(/*multiple*/ true, (filename, content) => {
+					if (files.includes(filename)) {
+						/*if(!confirm("Replace file \"" + filename + "\"\nAre you sure?"))
+                        {
+                            return;
+                        }*/
+					}
+					localStorage.setItem("tscript.code." + filename, content);
+					if (!files.includes(filename)) {
+						files.push(filename);
+						let option = new Option(filename, filename);
+						list.appendChild(option);
+					}
+				});
+			}
+		}
+
+		let divDeviceStorage = tgui.createElement({
+			parent: dlg.content,
+			type: "div",
+			style: { ...tabStyle, display: "none" },
+		});
+
+		{
+			if (mode == DialogMode.OPEN) {
+				loadDeviceBtn = tgui.createElement({
+					parent: divDeviceStorage,
+					type: "button",
+					style: {
+						width: "100%",
+						height: "25px",
+					},
+					text: "Load file from disk",
+					click: () => {
+						loadDevice(false, (filename, content) => {
+							onSelection(deviceFile(filename, content));
+							tgui.stopModal(dlg);
+						});
+					},
+					classname: "tgui-modal-button",
+				});
+			} else {
+				//tgui.createText("Type the filename into the text box and click on Save to download the file.", divDeviceStorage);
+			}
+		}
+
+		if (allowNewFilename) {
+			name = tgui.createElement({
+				parent: dlg.content,
+				type: "input",
+				style: {
+					height: "25px",
+					//background: "#fff",
+					margin: "0 0px 7px 0px",
+				},
+				classname: "tgui-text-box",
+
+				properties: {
+					type: "text",
+					placeholder: "Filename",
+					value: file.filename,
+				},
+			});
+			focusedElement = name;
+		}
+
+		if (file.isDevice) selectDevice();
+
+		tgui.startModal(dlg);
+		focusedElement.focus();
+		return dlg;
+	}
+
+	/*export function fileDlg(
+		title: string,
+		filename: string,
+		allowNewFilename: boolean,
+		confirmText: string,
+		onOkay
+	) {
+	}*/
+}

--- a/src/ide/tgui.ts
+++ b/src/ide/tgui.ts
@@ -1544,7 +1544,7 @@ export let tgui = (function () {
 	};
 
 	module.msgBoxQuestion = icons.msgBoxQuestion;
-
+	module.msgBoxInformation = icons.msgBoxInformation;
 	module.msgBoxExclamation = icons.msgBoxExclamation;
 
 	// Show a (newly created) modal dialog, that was created by createModal.


### PR DESCRIPTION
I have added tabs to the file dialog, namely the Browser Storage tab, which corresponds to the current file dialog, and the Device Storage tab. It might be useful to add further storage options here, like storing to moodle for example.

When selecting the device storage tab, files are directly saved as downloads. Also files can be loaded more easily from the device.

But one problem is, that the tab is currently pretty empty.

![save](https://user-images.githubusercontent.com/58823087/144754141-f50df531-c9f5-4328-a559-35c622ee8e2e.png)

One idea I have is to allow drag & drop in the open dialog, and another option would be to open the open dialog directly, when the tab is selected.

I have also worked on the export button and added some message boxes in cases where the export button might be ambiguous, like when the open dialog is opened and export is directly clicked.