### PR TITLE
IDE: Use operating system theme on first load

### DIFF
--- a/src/ide/doc.ts
+++ b/src/ide/doc.ts
@@ -22,15 +22,15 @@ export const doc = (function () {
 	let docpath = "";
 	let doctree: any = null;
 
-	// check if dark theme is activated
+	// load theme from localStorage or use the theme of the operating system
 	function loadTheme() {
 		let str = localStorage.getItem("tscript.ide.config");
+		let theme = "default";
 		if (str) {
 			let config = JSON.parse(str);
-			let theme = "default";
 			if (config.hasOwnProperty("theme")) theme = config.theme;
-			tgui.setTheme(theme);
 		}
+		tgui.setTheme(theme);
 		return null;
 	}
 

--- a/src/ide/ide.ts
+++ b/src/ide/ide.ts
@@ -1418,7 +1418,7 @@ export let ide = (function () {
 			}
 			if (config.hasOwnProperty("theme")) {
 				theme = config.theme;
-			}	
+			}
 		}
 		document.addEventListener("DOMContentLoaded", function () {
 			tgui.setTheme(theme);

--- a/src/ide/ide.ts
+++ b/src/ide/ide.ts
@@ -1418,11 +1418,11 @@ export let ide = (function () {
 			}
 			if (config.hasOwnProperty("theme")) {
 				theme = config.theme;
-			}
-			document.addEventListener("DOMContentLoaded", function () {
-				tgui.setTheme(theme);
-			});
+			}	
 		}
+		document.addEventListener("DOMContentLoaded", function () {
+			tgui.setTheme(theme);
+		});
 		return null;
 	}
 	loadConfig();


### PR DESCRIPTION
Issue: [https://github.com/TGlas/tscript/issues/123](https://github.com/TGlas/tscript/issues/123)

As proposed in the issue, the IDE now uses the operating system theme when no theme is saved in the local Storage.

I've decided to **not** change the constructor of `tgui.ts`.
I've overlooked that the theme needs to be set after the DOM is constructed. To implement my suggested "Option 2", I would have ve to register another event listener to "DOMContentLoaded". I decided not to do that to avoid risking interfering with other registered event handlers.

I've now changed the `doc.ts` and `ide.ts` files to always set the theme to "default" if no theme is specified in the local Storage.