### PR TITLE
CSS responsiveness for smaller window widths

### DIFF
--- a/src/ide/css/responsive.css
+++ b/src/ide/css/responsive.css
@@ -4,6 +4,10 @@
 	align-items: center;
 }
 
+.tgui-tree {
+	overflow: auto;
+}
+
 tbody {
 	max-width: 80vw;
 }
@@ -17,9 +21,19 @@ td {
 	max-width: 60vw;
 }
 
+@media screen and (max-width: 1000px) {
+	td {
+		max-width: 55vw;
+	}
+}
+
 /* Layout change to put the sidebar above the content */
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 756px) {
+	#version {
+		height: 20px;
+	}
+
 	#sidebar {
 		width: 100%;
 		max-height: 30%;
@@ -45,12 +59,13 @@ td {
 	}
 
 	#search {
+		top: 20px;
 		height: 34px;
 	}
 
 	#tree {
-		top: 80px;
-		height: calc(100% - 80px);
+		top: 54px;
+		height: calc(100% - 54px);
 	}
 
 	.dark-theme #content {
@@ -61,12 +76,17 @@ td {
 		display: grid;
 		grid-template-columns: 1fr 1fr 1fr;
 		gap: 0.5rem;
-
-		padding-bottom: 3rem;
+		padding-bottom: 2rem;
+		padding-top: 1rem;
 	}
 
 	#tree > div > table > tr:nth-child(1) {
+		display: flex;
 		grid-column: span 3;
+	}
+
+	td {
+		max-width: 68vw;
 	}
 }
 

--- a/src/ide/css/responsive.css
+++ b/src/ide/css/responsive.css
@@ -1,0 +1,89 @@
+#version {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
+tbody {
+	max-width: 80vw;
+}
+
+th {
+	max-width: 10vw;
+	min-width: 8rem;
+}
+
+td {
+	max-width: 60vw;
+}
+
+/* Layout change to put the sidebar above the content */
+
+@media screen and (max-width: 800px) {
+	#sidebar {
+		width: 100%;
+		max-height: 30%;
+		overflow: hidden;
+	}
+
+	.tgui-tree {
+		overflow-x: auto !important;
+	}
+
+	#content {
+		left: 0%;
+		top: 30%;
+		width: 100%;
+		height: 70%;
+
+		border-top: solid 5px #88c;
+	}
+
+	#searchtext {
+		margin: 2px;
+		width: calc(100% - 4px);
+	}
+
+	#search {
+		height: 34px;
+	}
+
+	#tree {
+		top: 80px;
+		height: calc(100% - 80px);
+	}
+
+	.dark-theme #content {
+		border-top: solid 5px #347;
+	}
+
+	#tree > div > table {
+		display: grid;
+		grid-template-columns: 1fr 1fr 1fr;
+		gap: 0.5rem;
+
+		padding-bottom: 3rem;
+	}
+
+	#tree > div > table > tr:nth-child(1) {
+		grid-column: span 3;
+	}
+}
+
+@media screen and (max-width: 540px) {
+	#tree > div > table {
+		grid-template-columns: 1fr 1fr;
+	}
+
+	#tree > div > table > tr:nth-child(1) {
+		grid-column: span 2;
+	}
+
+	#content {
+		padding: 2%;
+	}
+
+	td {
+		max-width: 62vw;
+	}
+}

--- a/src/ide/css/tgui.css
+++ b/src/ide/css/tgui.css
@@ -162,7 +162,7 @@
 	font-family: monospace;
 	font-size: 9pt;
 	line-height: 13px;
-	overflow: scroll;
+	overflow: auto;
 }
 
 .tgui-tree-main {

--- a/src/ide/index.ts
+++ b/src/ide/index.ts
@@ -9,6 +9,7 @@ import { searchengine } from "./search";
 import { showStandalonePage } from "./standalone";
 
 import "./css/documentation.css";
+import "./css/responsive.css";
 import "./css/icons.css";
 import "./css/ide.css";
 import "./css/tgui.css";


### PR DESCRIPTION
Reading the documentation on smaller page widths cuts off a lot of the content and sidebar.
These changes stack the sidebar above the content to allow for more room. 

_This is one potential idea. An alternative approach would be to make the sidebar collapsable._

Current CSS style:
<img src="https://github.com/user-attachments/assets/01d19b5b-c2eb-494b-b37c-134e6dc91849" width="200">

Proposed changes:
<img src="https://github.com/user-attachments/assets/dc0c54dc-b39e-45f3-988d-e9011167a275" width="200">