### PR TITLE
Cleanup/Typings of Editor Options and Themes

### DIFF
--- a/src/ide/doc.ts
+++ b/src/ide/doc.ts
@@ -30,7 +30,7 @@ export const doc = (function () {
 			let config = JSON.parse(str);
 			if (config.hasOwnProperty("theme")) theme = config.theme;
 		}
-		tgui.setTheme(theme);
+		if (tgui.isThemeConfig(theme)) tgui.setThemeConfig(theme);
 		return null;
 	}
 

--- a/src/ide/editor/editor.ts
+++ b/src/ide/editor/editor.ts
@@ -9,7 +9,7 @@ import {
 } from "./actions";
 import { Document } from "./document";
 import { Iterator } from "./iterators";
-import { Language, LanguageIdentifier } from "./language";
+import { HightlightColor, Language, LanguageIdentifier } from "./language";
 import { ThemeDefinition, themes } from "./theme";
 
 interface EditorOptions {
@@ -620,7 +620,7 @@ export class Editor {
 						ctx.fillRect(x, y, this.charwidth, this.em);
 					}
 					let uni = v[index] & 0x1fffff;
-					let col = (v[index] / 0x200000) & 15;
+					const col = ((v[index] / 0x200000) & 15) as HightlightColor;
 					if (uni > 32) {
 						// draw the character
 						ctx.fillStyle = colors[col];
@@ -633,7 +633,7 @@ export class Editor {
 					}
 					if (v[index] & 0x4000000) {
 						// draw the cursor
-						ctx.fillStyle = colors[0];
+						ctx.fillStyle = colors[HightlightColor.Plain];
 						ctx.fillRect(
 							x - 0.04 * this.charwidth,
 							y + 0.05 * this.em,

--- a/src/ide/editor/iterators.ts
+++ b/src/ide/editor/iterators.ts
@@ -1,6 +1,6 @@
 import { tabWidth, Node, Interior, Leaf } from "./tree";
 import { Document } from "./document";
-import { Language } from "./language";
+import { HightlightColor, Language } from "./language";
 
 // An iterator represents a position in a document.
 // It keeps track of character index (pos) and layout position (row/col),
@@ -202,12 +202,19 @@ export class Iterator {
 	public _advanced(c) {}
 }
 
+type OnHighlightCb = (
+	a: number,
+	b: number,
+	c: HightlightColor,
+	d: boolean
+) => void;
+
 // In addition to a plain Iterator, a HighlightingIterator runs the
 // language scanner while traversing the document in order to provide
 // syntax highlighting information.
 export class HighlightingIterator extends Iterator {
 	state: number;
-	private onHighlight: (a: number, b: number, c: number, d: boolean) => void;
+	private onHighlight: OnHighlightCb;
 
 	// Construct a highlighting iterator.
 	// The #onHighlight callback is called with the following arguments:
@@ -217,10 +224,7 @@ export class HighlightingIterator extends Iterator {
 	//   - num is the number of consecutive characters to be highlighted
 	//   - highlight is the color/style index
 	//   - bracket is true if the character is an active bracket
-	public constructor(
-		document: Document,
-		onHighlight: (a: number, b: number, c: number, d: boolean) => void
-	) {
+	public constructor(document: Document, onHighlight: OnHighlightCb) {
 		super(document);
 		this.state = this.leaf.state; // scanner state at the iterator position
 		this.onHighlight = onHighlight; // callback; invoked as soon as highlighting becomes unambiguous

--- a/src/ide/editor/language.ts
+++ b/src/ide/editor/language.ts
@@ -14,6 +14,19 @@ interface LanguageDefinition {
 	highlight: Record<string, string>;
 }
 
+export const enum HightlightColor {
+	Plain,
+	Keyword,
+	Bracket,
+	NumberLiteral,
+	StringLiteral,
+	EscapeSequence,
+	Brown, // unused
+	Orange, // unused
+	Yellow, // unused
+	Comment,
+}
+
 const language_definitions = {
 	plain: {
 		comments: {},
@@ -153,12 +166,14 @@ export class Language {
 			let state = name2state[rulename]!;
 			let trans = this.table[state];
 			let pos = 0;
-			let scanColor = () => {
+			let scanColor = (): HightlightColor => {
 				while (rule[pos] === " ") pos++;
-				for (let c in Language.scanner_colors) {
+				for (const [c, value] of Object.entries(
+					Language.scanner_colors
+				)) {
 					if (rule.substring(pos, pos + c.length) === c) {
 						pos += c.length;
-						return Language.scanner_colors[c];
+						return value;
 					}
 				}
 				throw "invalid scanner rule (" + pos + "): " + rule;
@@ -393,7 +408,7 @@ export class Language {
 	}
 
 	// access the components of a table entry individually
-	public static highlight(entry: number) {
+	public static highlight(entry: number): HightlightColor {
 		return entry & Language.scanresult_highlight_mask;
 	}
 	public static bracket(entry: number) {
@@ -420,19 +435,19 @@ export class Language {
 	private static readonly scanresult_pending_mask = 4096 - 64; // bit mask for the number of pending characters
 	private static readonly scanresult_pending = 64; // divisor for the number of pending characters
 	private static readonly scanresult_state = 4096; // divisor for the successor state
-	private static readonly scanner_colors = {
-		plain: 0,
-		black: 0, // plain in light theme
-		white: 0, // plain in dark theme
-		blue: 1,
-		green: 2,
-		cyan: 3,
-		red: 4,
-		magenta: 5,
-		brown: 6,
-		orange: 7,
-		yellow: 8,
-		gray: 9,
-		grey: 9,
+	private static readonly scanner_colors: Record<string, HightlightColor> = {
+		plain: HightlightColor.Plain,
+		black: HightlightColor.Plain, // plain in light theme
+		white: HightlightColor.Plain, // plain in dark theme
+		blue: HightlightColor.Keyword,
+		green: HightlightColor.Bracket,
+		cyan: HightlightColor.NumberLiteral,
+		red: HightlightColor.StringLiteral,
+		magenta: HightlightColor.EscapeSequence,
+		brown: HightlightColor.Brown,
+		orange: HightlightColor.Orange,
+		yellow: HightlightColor.Yellow,
+		gray: HightlightColor.Comment,
+		grey: HightlightColor.Comment,
 	};
 }

--- a/src/ide/editor/theme.ts
+++ b/src/ide/editor/theme.ts
@@ -6,6 +6,7 @@
 //
 
 import { ThemeName } from "../tgui";
+import { HightlightColor } from "./language";
 
 export interface ThemeDefinition {
 	bars: {
@@ -21,18 +22,7 @@ export interface ThemeDefinition {
 	};
 	content: {
 		background: string;
-		highlight: [
-			string,
-			string,
-			string,
-			string,
-			string,
-			string,
-			string,
-			string,
-			string,
-			string
-		];
+		highlight: Record<HightlightColor, string>;
 		cursorline: [string, string];
 		selection: [string, string];
 		bracket: [string, string];

--- a/src/ide/editor/theme.ts
+++ b/src/ide/editor/theme.ts
@@ -5,7 +5,48 @@
 // creating editor instances.
 //
 
-export let themes = {
+import { ThemeName } from "../tgui";
+
+export interface ThemeDefinition {
+	bars: {
+		linenumbers: {
+			background: string;
+			color: string;
+		};
+		icons: {
+			background: string;
+			color: string;
+		};
+		separator: string;
+	};
+	content: {
+		background: string;
+		highlight: [
+			string,
+			string,
+			string,
+			string,
+			string,
+			string,
+			string,
+			string,
+			string,
+			string
+		];
+		cursorline: [string, string];
+		selection: [string, string];
+		bracket: [string, string];
+	};
+	search: {
+		background: string;
+		separator: string;
+		fields: string;
+		color: string;
+		close: string;
+	};
+}
+
+export const themes: Record<ThemeName, ThemeDefinition> = {
 	light: {
 		bars: {
 			linenumbers: {

--- a/src/ide/elements/dialogs.ts
+++ b/src/ide/elements/dialogs.ts
@@ -1,11 +1,10 @@
 import { Options, defaultOptions } from "../../lang/helpers/options";
 import * as tgui from "./../tgui";
 import { buttons } from "./commands";
-import { tab_config, openEditorFromLocalStorage } from "./editor-tabs";
+import { tab_config } from "./editor-tabs";
 import * as ide from "./index";
 
 export let options: any = new Options();
-export let theme: string = "default";
 
 /**
  * Check if the document has been changed and when this is the case, ask the user to discard the changes,
@@ -64,9 +63,11 @@ export function loadConfig() {
 		if (config.hasOwnProperty("options")) {
 			options = Object.assign(options, defaultOptions, config.options);
 		}
-		if (config.hasOwnProperty("theme")) {
-			theme = config.theme;
-		}
+
+		const configuredTheme = config.theme;
+		tgui.setThemeConfig(
+			tgui.isThemeConfig(configuredTheme) ? configuredTheme : "default"
+		);
 	}
 	return config;
 }
@@ -78,7 +79,7 @@ export function saveConfig() {
 	let config: any = {
 		options: options,
 		hotkeys: [],
-		theme,
+		theme: tgui.getThemeConfig(),
 		tabs: tab_config,
 		open: ide.collection.getFilenames(),
 		main: ide.getRunSelection(),
@@ -276,7 +277,7 @@ export function configDlg() {
 			parent: div_appearance,
 			type: "p",
 		});
-		const themes = [
+		const themes: { id: tgui.ThemeConfiguration; display: string }[] = [
 			{ id: "default", display: "System Default" },
 			{ id: "light", display: "Light" },
 			{ id: "dark", display: "Dark" },
@@ -306,12 +307,10 @@ export function configDlg() {
 				html: t.display,
 			});
 		}
-		sel.value = theme;
-		sel.addEventListener("change", function (event) {
-			theme = sel.value;
-			tgui.setTheme(theme);
-			for (let editor of ide.collection.getEditors())
-				editor.setTheme(theme);
+		sel.value = tgui.getThemeConfig();
+		sel.addEventListener("change", () => {
+			const theme = sel.value as tgui.ThemeConfiguration;
+			tgui.setThemeConfig(theme);
 		});
 	}
 

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -618,10 +618,6 @@ export function create(container: HTMLElement, options?: any) {
 		state: "left",
 		fallbackState: "icon",
 		icon: icons.editor,
-		onThemeChange: function (theme) {
-			let eds = collection.getEditors();
-			for (let ed of eds) ed.setTheme(theme);
-		},
 	});
 	panel_editor.content.addEventListener("contextmenu", function (event) {
 		event.preventDefault();
@@ -993,8 +989,6 @@ export function create(container: HTMLElement, options?: any) {
 
 	tgui.arrangePanels();
 	window["TScriptIDE"] = { tgui: tgui, ide: module };
-
-	if (!standalone && config && config.theme) tgui.setTheme(config.theme);
 }
 
 /**

--- a/src/ide/tgui/index.ts
+++ b/src/ide/tgui/index.ts
@@ -1,19 +1,16 @@
 import { SVGIcon } from "../icons";
 import { setHotkey } from "./hotkeys";
 import { modal } from "./modals";
-import { panels } from "./panels";
 
 // re-exports
+export * from "./hotkeys";
 export * from "./modals";
 export * from "./panels";
-export * from "./hotkeys";
+export * from "./theme";
 
 ///////////////////////////////////////////////////////////
 // simplistic GUI framework
 //
-
-/** light theme, indicated by no theme css class in the body dom element which is the initial state */
-export let theme = "light";
 
 interface ElementDescription<T = keyof HTMLElementTagNameMap> {
 	/** HTML element type name */
@@ -611,40 +608,6 @@ export function setTooltip(
 		text: tooltip,
 		classname: "tgui tgui-tooltip tgui-tooltip-" + direction,
 	});
-}
-
-/**
- * set the theme
- */
-export function setTheme(newTheme: string) {
-	if (newTheme === "default") {
-		// Auto detect theme of the operating system
-		if (window.matchMedia) {
-			var q = window.matchMedia("(prefers-color-scheme: dark)");
-			newTheme = q.matches ? "dark" : "light";
-		} else {
-			newTheme = "light";
-		}
-	}
-
-	// Note that the light theme is represented in the body tag by no class at all
-	if (theme !== newTheme) {
-		if (newTheme === "light")
-			document.body.classList.remove(`${theme}-theme`);
-		else if (theme === "light")
-			document.body.classList.add(`${newTheme}-theme`);
-		else
-			document.body.classList.replace(
-				`${theme}-theme`,
-				`${newTheme}-theme`
-			);
-
-		theme = newTheme;
-
-		for (let panel of panels) {
-			if (panel.onThemeChange) panel.onThemeChange(newTheme);
-		}
-	}
 }
 
 export let separator = createElement({

--- a/src/ide/tgui/panels.ts
+++ b/src/ide/tgui/panels.ts
@@ -55,9 +55,6 @@ interface PanelDescription {
 	/** callback function on arranging (possible position/size change) */
 	onArrange?: () => any;
 
-	/** callback function on theme change */
-	onThemeChange?: (theme) => any;
-
 	/** TODO: document */
 	pos?: any;
 

--- a/src/ide/tgui/theme.ts
+++ b/src/ide/tgui/theme.ts
@@ -1,0 +1,64 @@
+/** Available themes */
+export type ThemeName = "light" | "dark";
+
+/**
+ * Selectable theme configurations: includes `default` for automatic theme detection
+ */
+export type ThemeConfiguration = "default" | ThemeName;
+
+export const isThemeConfig = (v: any): v is ThemeConfiguration =>
+	["light", "dark", "default"].includes(v);
+
+// The theme config starts as light (no class on <body>)
+// This is later replaced when the configuration is loaded
+let themeConfig: ThemeConfiguration = "light";
+export const getThemeConfig = () => themeConfig;
+
+let theme: ThemeName = "light";
+export const getResolvedTheme = () => theme;
+
+const themeListeners = new Set<() => void>();
+
+/**
+ * Listen to changes to the resolved theme
+ *
+ * @param handler the callback to call if the resolved theme has changed
+ * @returns a function that can be used to unsubscribe
+ */
+export function subscribeOnThemeChange(handler: () => void) {
+	themeListeners.add(handler);
+	return () => themeListeners.delete(handler);
+}
+
+const prefersDarkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+/** Resolve the theme by detecting the system theme */
+const resolveTheme = (config: ThemeConfiguration): ThemeName =>
+	config === "default"
+		? prefersDarkQuery.matches
+			? "dark"
+			: "light"
+		: config;
+
+/**
+ * Set the desired theme configuration
+ */
+export function setThemeConfig(newTheme: ThemeConfiguration) {
+	themeConfig = newTheme;
+	applyThemeConfig();
+}
+
+function applyThemeConfig() {
+	const newTheme = resolveTheme(themeConfig);
+	if (theme !== newTheme) {
+		// Remove old theme class, add new theme class (if applicable)
+		// Note that the light theme is represented in the body tag by no class at all
+		document.body.classList.remove(`${theme}-theme`);
+		if (newTheme !== "light")
+			document.body.classList.add(`${newTheme}-theme`);
+
+		theme = newTheme;
+
+		for (const listener of themeListeners) listener();
+	}
+}

--- a/src/ide/tutorial.ts
+++ b/src/ide/tutorial.ts
@@ -201,7 +201,7 @@ export const tutorial = (function () {
 								buttons: [{ text: "Close" }],
 							});
 							let editor = new Editor({
-								language: "TScript",
+								language: "tscript",
 								text: correct,
 								parent: dlg.content,
 								readOnly: true,


### PR DESCRIPTION
This PR primarily contains two changes:

- IDE/Editor themes have a type
- The options passed to the Editor constructor now have a type

These changes are related because the editor needs a theme type for its options and makes use of this type in multiple places.

## Cleanup of Theme Handling

While adding theme types, I cleaned up how IDE themes are handled and theme changes are propagated through the IDE.
Previously, there were **two different** variables keeping track of the current theme:

https://github.com/TGlas/tscript/blob/3d3ccb4a8bdeb4d7a4b3f8699768ce374ffb4751/src/ide/elements/dialogs.ts#L8
https://github.com/TGlas/tscript/blob/3d3ccb4a8bdeb4d7a4b3f8699768ce374ffb4751/src/ide/tgui/index.ts#L16

I encapsulated all state related to themes in `src/ide/tgui/theme.ts`. One remaining annoyance: the configured theme is still loaded in two different places, for the IDE and the docs respectively.

In addition, theme changes were propagated in a spaghetti-ish way. Editors were notified **twice**:

1. The configuration dialog iterated over editors and updated their themes.
1. `tgui/index.ts` iterated over all panels and called `onThemeChange` &rarr; the editor panel iterated over editors and updated their themes.

I replaced that with a simple subscription mechanism. `EditorCollection` subscribes to theme changes and notifies its editors. The editor used for reference solutions previously wasn't updated and I didn't change that.

## Typings for Editor Options

There's now a type for the options of the Editor constructor. This needed types for language identifiers, language definitions and theme definitions. Adding these types actually caused TypeScript to find two bugs in `language.ts`!
There are some places where I'm not sure I fully understood what the code is doing. I commented on these places below to clear things up.