### PR TITLE
Update actions and node version in CI and CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,23 +9,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       # Set up environment
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
-      - name: Set up NPM cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            npm-
+          node-version: 22
+          cache: npm
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,16 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       # Set up environment
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
-      - name: Set up NPM cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            npm-
+          node-version: 22
+          cache: npm
       - name: Install dependencies
         run: npm ci
 
@@ -45,20 +33,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 1
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
-      - name: Set up NPM cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            npm-
+          node-version: 22
+          cache: npm
       - run: npm ci
       - run: npm run test:fmt


### PR DESCRIPTION
CI and CD don't seem to work anymore since the versions of some of the used actions are outdated.

This updates workflow configurations to use the latest versions of these actions.
Additionally, the used node version is updated from 16.x (unsupported) to 22.x (LTS) (See [Node.js Releases](https://nodejs.org/en/about/previous-releases)).

I tested both [CI](https://github.com/Jartreg/tscript/actions/runs/13927404837) and [CD](https://github.com/Jartreg/tscript/actions/runs/13927325197) in my fork.