### PR TITLE
Decoupling the Standalone Page from the IDE

### DIFF
--- a/src/eval/createInterpreter.ts
+++ b/src/eval/createInterpreter.ts
@@ -1,10 +1,11 @@
 import { TScript } from "../lang";
 import { createDefaultServices } from "../lang/interpreter/defaultService";
 import { Interpreter } from "../lang/interpreter/interpreter";
+import { ProgramRoot } from "../lang/interpreter/program-elements";
 
 // create an interpreter with specialized services for observing the
 // runtime behavior of a program
-export function createInterpreter(program, inputs, output) {
+export function createInterpreter(program: ProgramRoot, inputs, output) {
 	let interpreter = new Interpreter(program, createDefaultServices());
 
 	// current image transformation

--- a/src/eval/hasStructure.ts
+++ b/src/eval/hasStructure.ts
@@ -1,9 +1,3 @@
-import { Typeid } from "../lang/helpers/typeIds";
-import { TScript } from "../lang";
-import { Parser } from "../lang/parser";
-import { createDefaultServices } from "../lang/interpreter/defaultService";
-import { Interpreter } from "../lang/interpreter/interpreter";
-import { escapeHtmlChars } from "../escape";
 import { reserved_node_names } from "./reserved_node_names";
 
 //

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -1,11 +1,4 @@
-import { Typeid } from "../lang/helpers/typeIds";
-import { TScript } from "../lang";
-import { Parser } from "../lang/parser";
-import { createDefaultServices } from "../lang/interpreter/defaultService";
-import { Interpreter } from "../lang/interpreter/interpreter";
 import { escapeHtmlChars } from "../escape";
-import { isRecursive } from "./isRecursive";
-import { hasStructure } from "./hasStructure";
 import { run_multiple } from "./run_multiple";
 
 //

--- a/src/eval/isRecursive.ts
+++ b/src/eval/isRecursive.ts
@@ -1,10 +1,11 @@
 import { Typeid } from "../lang/helpers/typeIds";
 import { createDefaultServices } from "../lang/interpreter/defaultService";
 import { Interpreter } from "../lang/interpreter/interpreter";
+import { ProgramRoot } from "../lang/interpreter/program-elements";
 import { reserved_node_names } from "./reserved_node_names";
 
 // static code analysis, try to decide whether a program contains a recursive function or not
-function isRecursiveStatic(program) {
+function isRecursiveStatic(program: ProgramRoot) {
 	if (!program) return false;
 
 	function isObject(value) {
@@ -48,7 +49,11 @@ function isRecursiveStatic(program) {
 }
 
 // dynamic behavior analysis, try to decide whether a program contains a recursive function or not
-function isRecursiveDynamic(program, maxseconds = 3.0, inputs = []) {
+function isRecursiveDynamic(
+	program: ProgramRoot,
+	maxseconds = 3.0,
+	inputs = []
+) {
 	if (!program) return false;
 	inputs = inputs.slice();
 
@@ -136,7 +141,7 @@ function isRecursiveDynamic(program, maxseconds = 3.0, inputs = []) {
 // recursion is found then the program is executed -- hence make sure to
 // include test code that actually invokes the recursion -- and the
 // runtime behavior is analyzed.
-export function isRecursive(program) {
+export function isRecursive(program: ProgramRoot) {
 	if (isRecursiveStatic(program)) return true;
 	else return isRecursiveDynamic(program);
 }

--- a/src/eval/isRecursive.ts
+++ b/src/eval/isRecursive.ts
@@ -1,9 +1,6 @@
 import { Typeid } from "../lang/helpers/typeIds";
-import { TScript } from "../lang";
-import { Parser } from "../lang/parser";
 import { createDefaultServices } from "../lang/interpreter/defaultService";
 import { Interpreter } from "../lang/interpreter/interpreter";
-import { escapeHtmlChars } from "../escape";
 import { reserved_node_names } from "./reserved_node_names";
 
 // static code analysis, try to decide whether a program contains a recursive function or not

--- a/src/eval/run_multiple.ts
+++ b/src/eval/run_multiple.ts
@@ -44,8 +44,8 @@ export function run_multiple(code, inputs, maxseconds, process) {
 			else compute();
 		} else {
 			let result = parseProgramFromString(c);
-			let errors = result.errors;
-			if (errors.length > 0) {
+			if (!result.program) {
+				let errors = result.errors;
 				for (let i = 0; i < errors.length; i++) {
 					let err = errors[i];
 					output.push({

--- a/src/eval/run_multiple.ts
+++ b/src/eval/run_multiple.ts
@@ -1,5 +1,4 @@
-import { Parser } from "../lang/parser";
-import { Interpreter } from "../lang/interpreter/interpreter";
+import { parseProgramFromString } from "../lang/parser";
 import { isRecursive } from "./isRecursive";
 import { hasStructure } from "./hasStructure";
 import { createInterpreter } from "./createInterpreter";
@@ -32,14 +31,19 @@ export function run_multiple(code, inputs, maxseconds, process) {
 					"\nreturn null; };\n"
 			);
 			all.push(
-				testfunction(tsc, Parser.parse, hasStructure, isRecursive)
+				testfunction(
+					tsc,
+					parseProgramFromString,
+					hasStructure,
+					isRecursive
+				)
 			);
 			output = new Array();
 			index++;
 			if (index === code.length) process(all);
 			else compute();
 		} else {
-			let result = Parser.parse(c);
+			let result = parseProgramFromString(c);
 			let errors = result.errors;
 			if (errors.length > 0) {
 				for (let i = 0; i < errors.length; i++) {

--- a/src/eval/run_tscript.ts
+++ b/src/eval/run_tscript.ts
@@ -1,6 +1,5 @@
 import { Typeid } from "../lang/helpers/typeIds";
-import { Parser } from "../lang/parser";
-import { Interpreter } from "../lang/interpreter/interpreter";
+import { parseProgramFromString } from "../lang/parser";
 import { createInterpreter } from "./createInterpreter";
 
 // This function runs a TScript program. It returns an array of
@@ -13,7 +12,7 @@ export function run_tscript(code, maxseconds = 3.0, inputs = []) {
 	inputs = inputs.slice();
 	let output = new Array();
 
-	let result = Parser.parse(code);
+	let result = parseProgramFromString(code);
 	let errors = result.errors;
 	if (errors.length > 0) {
 		for (let i = 0; i < errors.length; i++) {

--- a/src/eval/run_tscript.ts
+++ b/src/eval/run_tscript.ts
@@ -13,8 +13,8 @@ export function run_tscript(code, maxseconds = 3.0, inputs = []) {
 	let output = new Array();
 
 	let result = parseProgramFromString(code);
-	let errors = result.errors;
-	if (errors.length > 0) {
+	if (!result.program) {
+		let errors = result.errors;
 		for (let i = 0; i < errors.length; i++) {
 			let err = errors[i];
 			output.push({

--- a/src/ide/doc.ts
+++ b/src/ide/doc.ts
@@ -2,7 +2,7 @@ import { documentationData } from "../doc";
 import { ErrorHelper } from "../lang/errors/ErrorHelper";
 import { createDefaultServices } from "../lang/interpreter/defaultService";
 import { Interpreter } from "../lang/interpreter/interpreter";
-import { defaultParseOptions, Parser } from "../lang/parser";
+import { defaultParseOptions, parseProgramFromString } from "../lang/parser";
 import { Lexer } from "../lang/parser/lexer";
 import { Version } from "../lang/version";
 import { navigate } from "./navigation";
@@ -276,7 +276,7 @@ export const doc = (function () {
 	// Check code for correctness by parsing and running it.
 	// On success, the function does nothing, otherwise is throws an error message.
 	function checkCode(code) {
-		let result = Parser.parse(code);
+		let result = parseProgramFromString(code);
 		if (result.hasOwnProperty("errors") && result.errors.length > 0)
 			throw result.errors[0].message;
 		let interpreter = new Interpreter(

--- a/src/ide/doc.ts
+++ b/src/ide/doc.ts
@@ -1,9 +1,8 @@
 import { documentationData } from "../doc";
 import { ErrorHelper } from "../lang/errors/ErrorHelper";
-import { defaultOptions } from "../lang/helpers/options";
 import { createDefaultServices } from "../lang/interpreter/defaultService";
 import { Interpreter } from "../lang/interpreter/interpreter";
-import { Parser } from "../lang/parser";
+import { defaultParseOptions, Parser } from "../lang/parser";
 import { Lexer } from "../lang/parser/lexer";
 import { Version } from "../lang/version";
 import { navigate } from "./navigation";
@@ -183,7 +182,7 @@ export const doc = (function () {
 				return { type: "comment" };
 			}
 		} else {
-			let ret = Lexer.get_token(state, defaultOptions, true);
+			let ret = Lexer.get_token(state, defaultParseOptions, true);
 			state.advance(ret.code.length);
 			return ret;
 		}

--- a/src/ide/doc.ts
+++ b/src/ide/doc.ts
@@ -277,8 +277,7 @@ export const doc = (function () {
 	// On success, the function does nothing, otherwise is throws an error message.
 	function checkCode(code) {
 		let result = parseProgramFromString(code);
-		if (result.hasOwnProperty("errors") && result.errors.length > 0)
-			throw result.errors[0].message;
+		if (!result.program) throw result.errors[0].message;
 		let interpreter = new Interpreter(
 			result.program,
 			createDefaultServices()

--- a/src/ide/elements/collection.ts
+++ b/src/ide/elements/collection.ts
@@ -41,13 +41,6 @@ export class EditorCollection {
 		return a;
 	}
 
-	// obtain the texts (strings) represented by all editors
-	public getValues() {
-		let values: Record<string, string> = {};
-		for (let ed of this.editors) values[ed.properties().name] = ed.text();
-		return values;
-	}
-
 	public setActiveEditor(ed: Editor | null, save_config: boolean = true) {
 		if (ed === this.active) return;
 

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -1,5 +1,5 @@
 import * as ide from ".";
-import { Parser } from "../../lang/parser";
+import { parseProgram } from "../../lang/parser";
 import { icons } from "../icons";
 import * as tgui from "./../tgui";
 import { fileDlg, parseOptions } from "./dialogs";
@@ -150,7 +150,7 @@ export function cmd_export() {
 	};
 
 	// check that the code at least compiles
-	let result = Parser.parse(toParse, parseOptions);
+	let result = parseProgram(toParse, parseOptions);
 	let program = result.program;
 	let errors = result.errors;
 	if (errors && errors.length > 0) {

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -9,7 +9,7 @@ import {
 	openEditorFromLocalStorage,
 } from "./editor-tabs";
 import { showdoc, showdocConfirm } from "./show-docs";
-import { updateControls } from "./utils";
+import { interpreterEnded, updateControls } from "./utils";
 
 export let buttons: any = [
 	{
@@ -96,37 +96,38 @@ function cmd_reset() {
 	updateControls();
 }
 
+/**
+ * Gets the active interpreter session or creates a new one if no program is running
+ */
+function getOrRestartSession() {
+	let session = ide.interpreterSession;
+	if (!session || interpreterEnded(session.interpreter)) {
+		// (re-)start the interpreter
+		session = ide.prepareRun();
+	}
+
+	return session;
+}
+
 function cmd_run() {
-	if (isInterpreterBusy()) ide.prepare_run();
-	if (!ide.interpreter) return;
-	ide.interpreter.run();
-	ide.canvas.parentElement.focus();
+	getOrRestartSession()?.interpreter.run();
 }
 
 function cmd_interrupt() {
-	if (isInterpreterBusy()) return;
-	ide.interpreter!.interrupt();
+	const interpreter = ide.interpreterSession?.interpreter;
+	if (interpreter && !interpreterEnded(interpreter)) interpreter.interrupt();
 }
 
 function cmd_step_into() {
-	if (isInterpreterBusy()) ide.prepare_run();
-	if (!ide.interpreter) return;
-	if ((ide.interpreter as any).running) return;
-	ide.interpreter.step_into();
+	getOrRestartSession()?.interpreter.step_into();
 }
 
 function cmd_step_over() {
-	if (isInterpreterBusy()) ide.prepare_run();
-	if (!ide.interpreter) return;
-	if ((ide.interpreter as any).running) return;
-	ide.interpreter.step_over();
+	getOrRestartSession()?.interpreter.step_over();
 }
 
 function cmd_step_out() {
-	if (isInterpreterBusy()) ide.prepare_run();
-	if (!ide.interpreter) return;
-	if ((ide.interpreter as any).running) return;
-	ide.interpreter.step_out();
+	getOrRestartSession()?.interpreter.step_out();
 }
 
 export function cmd_export() {
@@ -141,7 +142,7 @@ export function cmd_export() {
 	}
 
 	const parsedFiles = new Map<string, ParseInput>();
-	const parseInput = ide.createParseInput(undefined, parsedFiles);
+	const parseInput = ide.createParseInput(parsedFiles);
 	if (!parseInput) return;
 
 	ide.clear();
@@ -387,13 +388,4 @@ export function cmd_download() {
 	});
 	link.click();
 	link.remove();
-}
-
-function isInterpreterBusy() {
-	return (
-		!ide.interpreter ||
-		(ide.interpreter.status != "running" &&
-			ide.interpreter.status != "waiting" &&
-			ide.interpreter.status != "dialog")
-	);
 }

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -2,7 +2,7 @@ import * as ide from ".";
 import { Parser } from "../../lang/parser";
 import { icons } from "../icons";
 import * as tgui from "./../tgui";
-import { fileDlg, options } from "./dialogs";
+import { fileDlg, parseOptions } from "./dialogs";
 import {
 	closeEditor,
 	createEditorTabByModal,
@@ -150,7 +150,7 @@ export function cmd_export() {
 	};
 
 	// check that the code at least compiles
-	let result = Parser.parse(toParse, options);
+	let result = Parser.parse(toParse, parseOptions);
 	let program = result.program;
 	let errors = result.errors;
 	if (errors && errors.length > 0) {

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -164,10 +164,10 @@ export function cmd_export() {
 					err.line +
 					": " +
 					err.message,
-				err.filename,
+				err.filename ?? undefined,
 				err.line,
 				err.ch,
-				err.href
+				err.type === "error" ? err.href : undefined
 			);
 		}
 		return;

--- a/src/ide/elements/create-interpreter.ts
+++ b/src/ide/elements/create-interpreter.ts
@@ -1,0 +1,322 @@
+import { TScript } from "../../lang";
+import { Typeid } from "../../lang/helpers/typeIds";
+import { createDefaultServices } from "../../lang/interpreter/defaultService";
+import { Interpreter } from "../../lang/interpreter/interpreter";
+import { ProgramRoot } from "../../lang/interpreter/program-elements";
+import * as tgui from "../tgui";
+import { interpreterEnded } from "./utils";
+
+/**
+ * Create an Interpreter and configure it for use in the IDE or standalone
+ */
+export function createIDEInterpreter(program: ProgramRoot) {
+	const service: any = createDefaultServices();
+	service.documentation_mode = false;
+	service.alert = (msg: string) =>
+		new Promise((resolve, reject) => {
+			tgui.msgBox({
+				title: "",
+				prompt: msg,
+				buttons: [{ text: "Okay", isDefault: true }],
+				enterConfirms: true,
+				onClose: () => {
+					resolve(null);
+					return false;
+				},
+			});
+		});
+	service.confirm = (msg: string) =>
+		new Promise((resolve, reject) => {
+			let value = false;
+			tgui.msgBox({
+				title: "Question",
+				prompt: msg,
+				icon: tgui.msgBoxQuestion,
+				buttons: [
+					{
+						text: "Yes",
+						isDefault: true,
+						onClick: () => {
+							value = true;
+							return false;
+						},
+					},
+					{
+						text: "No",
+						isDefault: false,
+						onClick: () => {
+							value = false;
+							return false;
+						},
+					},
+				],
+				enterConfirms: true,
+				onClose: () => {
+					resolve(value);
+					return false;
+				},
+			});
+		});
+	service.prompt = (msg: string) =>
+		new Promise((resolve, reject) => {
+			const input = tgui.createElement({
+				type: "input",
+				classname: "ide-prompt-input",
+				properties: { type: "text" },
+			});
+			let value: string | null = null;
+			const dlg = tgui.createModal({
+				title: "Input",
+				scalesize: [0.2, 0.15],
+				minsize: [400, 250],
+				buttons: [
+					{
+						text: "Okay",
+						isDefault: true,
+						onClick: () => {
+							value = input.value;
+							return false;
+						},
+					},
+					{
+						text: "Cancel",
+						isDefault: false,
+						onClick: () => {
+							return false;
+						},
+					},
+				],
+				enterConfirms: true,
+				onClose: () => {
+					resolve(value);
+					return false;
+				},
+			});
+			tgui.createElement({
+				type: "p",
+				parent: dlg.content,
+				text: msg,
+				style: {
+					"white-space": "pre-wrap", // do linebreaks
+				},
+			});
+			dlg.content.appendChild(input);
+			tgui.startModal(dlg);
+			input.focus();
+		});
+
+	const interpreter = new Interpreter(program, service);
+	interpreter.eventnames["canvas.resize"] = true;
+	interpreter.eventnames["canvas.mousedown"] = true;
+	interpreter.eventnames["canvas.mouseup"] = true;
+	interpreter.eventnames["canvas.mousemove"] = true;
+	interpreter.eventnames["canvas.mouseout"] = true;
+	interpreter.eventnames["canvas.keydown"] = true;
+	interpreter.eventnames["canvas.keyup"] = true;
+	interpreter.eventnames["timer"] = true;
+	interpreter.reset();
+	return interpreter;
+}
+
+export function createTurtle(container: HTMLElement, signal?: AbortSignal) {
+	const turtle = document.createElement("canvas");
+	turtle.className = "ide ide-turtle";
+	turtle.width = 600;
+	turtle.height = 600;
+
+	turtle.addEventListener("contextmenu", (event) => {
+		event.preventDefault();
+	});
+
+	// ensure that the turtle area remains square and centered
+	function resize(w: number, h: number) {
+		const size = Math.min(w, h);
+		turtle.style.width = size + "px";
+		turtle.style.height = size + "px";
+	}
+	const containerRect = container.getBoundingClientRect();
+	resize(containerRect.width, containerRect.height);
+
+	const resizeObserver = new ResizeObserver((entries) => {
+		const size = entries[0].contentBoxSize[0];
+		resize(size.inlineSize, size.blockSize);
+	});
+	resizeObserver.observe(container);
+	signal?.addEventListener("abort", () => resizeObserver.disconnect());
+
+	// reset content
+	const ctx = turtle.getContext("2d")!;
+	ctx.setTransform(1, 0, 0, 1, 0, 0);
+	ctx.clearRect(0, 0, turtle.width, turtle.height);
+
+	return turtle;
+}
+
+export function createCanvas(
+	interpreter: Interpreter,
+	container: HTMLElement,
+	signal?: AbortSignal
+): HTMLCanvasElement {
+	const canvas = document.createElement("canvas");
+	canvas.width = container.clientWidth;
+	canvas.height = container.clientHeight;
+
+	// resize the canvas with its container
+	const resizeObserver = new ResizeObserver((entries) => {
+		const size = entries[0].contentBoxSize[0];
+		canvas.width = size.inlineSize;
+		canvas.height = size.blockSize;
+
+		const event = createTypedEvent("canvas.ResizeEvent", {
+			width: size.inlineSize,
+			height: size.blockSize,
+		});
+		interpreter.enqueueEvent("canvas.resize", event);
+	});
+	resizeObserver.observe(container);
+	signal?.addEventListener("abort", () => resizeObserver.disconnect());
+
+	// reset canvas content
+	const ctx = canvas.getContext("2d")!;
+	ctx.setTransform(1, 0, 0, 1, 0, 0);
+	ctx.clearRect(0, 0, canvas.width, canvas.height);
+	ctx.lineWidth = 1;
+	ctx.fillStyle = "#000";
+	ctx.strokeStyle = "#000";
+	ctx.font = "16px Helvetica";
+	ctx.textAlign = "left";
+	ctx.textBaseline = "top";
+
+	canvas.addEventListener("contextmenu", (event) => {
+		event.preventDefault();
+	});
+
+	// mouse events
+	canvas.addEventListener("mousedown", (event) => {
+		if (!isRunning(interpreter)) return;
+		const e = createTypedEvent(
+			"canvas.MouseButtonEvent",
+			mouseEventData(event, buttonName(event.button))
+		);
+		interpreter.enqueueEvent("canvas.mousedown", e);
+	});
+	canvas.addEventListener("mouseup", (event) => {
+		if (!isRunning(interpreter)) return;
+		const e = createTypedEvent(
+			"canvas.MouseButtonEvent",
+			mouseEventData(event, buttonName(event.button))
+		);
+		interpreter.enqueueEvent("canvas.mouseup", e);
+	});
+	canvas.addEventListener("mousemove", (event) => {
+		if (!isRunning(interpreter)) return;
+		const e = createTypedEvent(
+			"canvas.MouseMoveEvent",
+			mouseEventData(event)
+		);
+		interpreter.enqueueEvent("canvas.mousemove", e);
+	});
+	canvas.addEventListener("mouseout", () => {
+		if (!isRunning(interpreter)) return;
+		const e = {
+			type: interpreter.program.types[Typeid.typeid_null],
+			value: { b: null },
+		};
+		interpreter.enqueueEvent("canvas.mouseout", e);
+	});
+
+	// keyboard events
+	container.addEventListener(
+		"keydown",
+		(event) => {
+			if (!isRunning(interpreter)) return;
+			const e = createTypedEvent(
+				"canvas.KeyboardEvent",
+				keyboardEventData(event)
+			);
+			interpreter.enqueueEvent("canvas.keydown", e);
+		},
+		{ signal }
+	);
+	container.addEventListener(
+		"keyup",
+		(event) => {
+			if (!isRunning(interpreter)) return;
+			const e = createTypedEvent(
+				"canvas.KeyboardEvent",
+				keyboardEventData(event)
+			);
+			interpreter.enqueueEvent("canvas.keyup", e);
+		},
+		{ signal }
+	);
+
+	function createTypedEvent(displayname: string, dict: object): any {
+		const p = interpreter.program;
+		for (let idx = 10; idx < p.types.length; idx++) {
+			const t = p.types[idx];
+			if (t.displayname === displayname) {
+				// create the object without calling the constructor, considering default values, etc
+				const obj: any = { type: t, value: { a: [] } };
+				const n = {
+					type: p.types[Typeid.typeid_null],
+					value: { b: null },
+				};
+				for (let i = 0; i < t.objectsize; i++) obj.value.a.push(n);
+
+				// fill its attributes
+				for (const key in t.members) {
+					if (!dict.hasOwnProperty(key)) continue;
+					obj.value.a[t.members[key].id] = TScript.json2typed.call(
+						interpreter,
+						dict[key]
+					);
+				}
+				return obj;
+			}
+		}
+		throw new Error("[createTypedEvent] unknown type " + displayname);
+	}
+
+	return canvas;
+}
+
+const isRunning = (interpreter: Interpreter) =>
+	interpreter.background && !interpreterEnded(interpreter);
+
+function mouseEventData(event: MouseEvent, button?: string) {
+	const el = event.currentTarget as HTMLElement;
+	const canvasRect = el.getBoundingClientRect();
+	return {
+		x: event.clientX - canvasRect.x,
+		y: event.clientY - canvasRect.y,
+		button,
+		buttons: buttonNames(event.buttons),
+		shift: event.shiftKey,
+		control: event.ctrlKey,
+		alt: event.altKey,
+		meta: event.metaKey,
+	};
+}
+
+function buttonName(button: number): string {
+	if (button === 0) return "left";
+	else if (button === 1) return "middle";
+	else return "right";
+}
+
+function buttonNames(buttons: number) {
+	const result: string[] = [];
+	if (buttons & 1) result.push("left");
+	if (buttons & 4) result.push("middle");
+	if (buttons & 2) result.push("right");
+	return result;
+}
+
+const keyboardEventData = (event: KeyboardEvent) => ({
+	key: event.key,
+	shift: event.shiftKey,
+	control: event.ctrlKey,
+	alt: event.altKey,
+	meta: event.metaKey,
+});

--- a/src/ide/elements/dialogs.ts
+++ b/src/ide/elements/dialogs.ts
@@ -1,10 +1,10 @@
-import { Options, defaultOptions } from "../../lang/helpers/options";
+import { defaultParseOptions, ParseOptions } from "../../lang/parser";
 import * as tgui from "./../tgui";
 import { buttons } from "./commands";
 import { tab_config } from "./editor-tabs";
 import * as ide from "./index";
 
-export let options: any = new Options();
+export let parseOptions: ParseOptions = defaultParseOptions;
 
 /**
  * Check if the document has been changed and when this is the case, ask the user to discard the changes,
@@ -61,7 +61,10 @@ export function loadConfig() {
 			}
 		}
 		if (config.hasOwnProperty("options")) {
-			options = Object.assign(options, defaultOptions, config.options);
+			parseOptions = {
+				...defaultParseOptions,
+				...config.options,
+			};
 		}
 
 		const configuredTheme = config.theme;
@@ -77,7 +80,7 @@ export function loadConfig() {
  */
 export function saveConfig() {
 	let config: any = {
-		options: options,
+		options: parseOptions,
 		hotkeys: [],
 		theme: tgui.getThemeConfig(),
 		tabs: tab_config,
@@ -338,7 +341,7 @@ export function configDlg() {
 			id: "chkCodingStyle",
 			properties: { type: "checkbox" },
 			click: function (event) {
-				options.checkstyle = checkbox.checked;
+				parseOptions.checkstyle = checkbox.checked;
 			},
 		});
 		let lbl = tgui.createElement({
@@ -348,7 +351,7 @@ export function configDlg() {
 			properties: { for: "chkCodingStyle" },
 			style: { "padding-left": "5px" },
 		});
-		if (options.checkstyle) checkbox.checked = true;
+		if (parseOptions.checkstyle) checkbox.checked = true;
 	}
 
 	tgui.startModal(dlg);

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -199,26 +199,21 @@ export function prepare_run(runSelection?: string) {
 	const parseInput = createParseInput(runSelection);
 	if (!parseInput) return;
 
-	let result = parseProgram(parseInput, parseOptions);
-	let program = result.program;
-	let errors = result.errors;
-	if (errors) {
-		for (let i = 0; i < errors.length; i++) {
-			let err = errors[i];
-			addMessage(
-				err.type,
-				err.type +
-					(err.filename ? " in file '" + err.filename + "'" : "") +
-					" in line " +
-					err.line +
-					": " +
-					err.message,
-				err.filename ?? undefined,
-				err.line,
-				err.ch,
-				err.type === "error" ? err.href : undefined
-			);
-		}
+	const { program, errors } = parseProgram(parseInput, parseOptions);
+	for (const err of errors) {
+		addMessage(
+			err.type,
+			err.type +
+				(err.filename ? " in file '" + err.filename + "'" : "") +
+				" in line " +
+				err.line +
+				": " +
+				err.message,
+			err.filename ?? undefined,
+			err.line,
+			err.ch,
+			err.type === "error" ? err.href : undefined
+		);
 	}
 
 	if (program) {

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -9,7 +9,7 @@ import { icons } from "../icons";
 import * as tgui from "../tgui";
 import { tutorial } from "../tutorial";
 import { buttons, cmd_upload, cmd_download, cmd_export } from "./commands";
-import { configDlg, loadConfig, saveConfig, options } from "./dialogs";
+import { configDlg, loadConfig, saveConfig, parseOptions } from "./dialogs";
 import { showdoc, showdocConfirm } from "./show-docs";
 import * as utils from "./utils";
 import { EditorCollection } from "./collection";
@@ -177,7 +177,7 @@ export function prepare_run(run_selection: string | null = null) {
 		main: run_selection ? run_selection : getRunSelection(),
 	};
 
-	let result = Parser.parse(toParse, options);
+	let result = Parser.parse(toParse, parseOptions);
 	let program = result.program;
 	let errors = result.errors;
 	if (errors) {

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -1,8 +1,5 @@
-import { TScript } from "../../lang";
-import { get_function } from "../../lang/helpers/getParents";
-import { Typeid } from "../../lang/helpers/typeIds";
-import { createDefaultServices } from "../../lang/interpreter/defaultService";
 import { Interpreter } from "../../lang/interpreter/interpreter";
+import { ProgramRoot } from "../../lang/interpreter/program-elements";
 import { ParseInput, parseProgram } from "../../lang/parser";
 import { toClipboard } from "../clipboard";
 import { icons } from "../icons";
@@ -18,6 +15,11 @@ import {
 	createEditorTab,
 	openEditorFromLocalStorage,
 } from "./editor-tabs";
+import {
+	createCanvas,
+	createIDEInterpreter,
+	createTurtle,
+} from "./create-interpreter";
 
 export { createEditorTab };
 
@@ -26,11 +28,7 @@ export { createEditorTab };
 //
 
 export let collection!: EditorCollection;
-export let turtle: any = null;
-export let canvas: any = null;
 export let editor_title: any = null;
-export let createTypedEvent: any = null;
-
 export let panel_editor: any = null;
 export let editorcontainer: any = null;
 export let editortabs: any = null;
@@ -42,20 +40,18 @@ export let stacktree: any = null;
 export let programtree: any = null;
 export let programstate: any = null;
 
+let canvasContainer!: HTMLElement;
+let turtleContainer!: HTMLElement;
+
 /** current interpreter, non-null after successful parsing */
 export let interpreter: Interpreter | null = null;
+export let interpreterSession: InterpreterSession | null = null;
 
 let main: any = null;
 let toolbar: any = null;
 let iconlist: any = null;
 let highlight: any = null;
 export let runselector: HTMLSelectElement;
-
-let standalone: boolean = false;
-
-export function setStandalone(_standalone: boolean) {
-	standalone = _standalone;
-}
 
 /**
  * add a message to the message panel
@@ -139,37 +135,19 @@ export function addMessage(
  * put the IDE into "not yet checked" mode.
  */
 export function clear() {
-	if (interpreter) {
-		interpreter.stopthread();
-		//interpreter.service.turtle.reset.call(interpreter, 0, 0, 0, true);
-	}
+	interpreterSession?.destroy();
+	interpreterSession = null;
 	interpreter = null;
 
 	tgui.clearElement(messages);
-
-	let turtle_ctx = turtle.getContext("2d");
-	turtle_ctx.setTransform(1, 0, 0, 1, 0, 0);
-	turtle_ctx.clearRect(0, 0, turtle.width, turtle.height);
-
-	let canvas_ctx = canvas.getContext("2d");
-	canvas_ctx.setTransform(1, 0, 0, 1, 0, 0);
-	canvas_ctx.clearRect(0, 0, canvas.width, canvas.height);
-	canvas_ctx.lineWidth = 1;
-	canvas_ctx.fillStyle = "#000";
-	canvas_ctx.strokeStyle = "#000";
-	canvas_ctx.font = "16px Helvetica";
-	canvas_ctx.textAlign = "left";
-	canvas_ctx.textBaseline = "top";
 }
 
 /**
  * Create ParseInput from the current editors
  *
- * @param runSelection the name of the selected file to run
  * @returns a ParseInput object or `null` if no editors are open
  */
 export function createParseInput(
-	runSelection = getRunSelection(),
 	files = new Map<string, ParseInput>()
 ): ParseInput | null {
 	function getFile(filename: string): ParseInput | null {
@@ -186,18 +164,18 @@ export function createParseInput(
 		return file;
 	}
 
-	return getFile(runSelection);
+	return getFile(getRunSelection());
 }
 
 /**
  * Prepare everything for the program to start running,
  * put the IDE into stepping mode at the start of the program.
  */
-export function prepare_run(runSelection?: string) {
+export function prepareRun(): InterpreterSession | null {
 	clear();
 
-	const parseInput = createParseInput(runSelection);
-	if (!parseInput) return;
+	const parseInput = createParseInput();
+	if (!parseInput) return null;
 
 	const { program, errors } = parseProgram(parseInput, parseOptions);
 	for (const err of errors) {
@@ -215,13 +193,52 @@ export function prepare_run(runSelection?: string) {
 			err.type === "error" ? err.href : undefined
 		);
 	}
+	if (!program) return null;
 
-	if (program) {
-		interpreter = new Interpreter(program, createDefaultServices());
-		interpreter.service.documentation_mode = false;
-		interpreter.service.print = function (msg) {
+	interpreterSession = new InterpreterSession(
+		program,
+		turtleContainer,
+		canvasContainer
+	);
+	interpreter = interpreterSession.interpreter;
+
+	for (let ed of collection.getEditors()) {
+		// set and correct breakpoints
+		let br = ed.properties().breakpoints;
+		let a = new Array<number>();
+		for (let line of br) a.push(line + 1);
+
+		let result = interpreter.defineBreakpoints(a, ed.properties().name);
+		if (result !== null) {
+			for (let line of br)
+				if (!result.has(line)) ed.properties().toggleBreakpoint(line);
+			for (let line of result)
+				if (!br.has(line)) ed.properties().toggleBreakpoint(line);
+		}
+	}
+
+	return interpreterSession;
+}
+
+class InterpreterSession {
+	readonly interpreter: Interpreter;
+
+	readonly #controller = new AbortController();
+	readonly #canvas: HTMLCanvasElement;
+	readonly #turtle: HTMLCanvasElement;
+
+	constructor(
+		program: ProgramRoot,
+		turtleContainer: HTMLElement,
+		canvasContainer: HTMLElement
+	) {
+		const interpreter = createIDEInterpreter(program);
+		this.interpreter = interpreter;
+
+		// add IDE-specific properties
+		interpreter.service.print = (msg: string) => {
 			if (msg.length > 1000) {
-				let m = addMessage(
+				const m = addMessage(
 					"print",
 					"[truncated long message; click the symbol to copy the full message to the clipboard]\n" +
 						msg.substr(0, 1000) +
@@ -230,164 +247,56 @@ export function prepare_run(runSelection?: string) {
 				m.content.classList.add("ide-truncation");
 				m.symbol.innerHTML = "&#x1f4cb;";
 				m.symbol.style.cursor = "copy";
-				m.symbol.addEventListener(
-					"click",
-					(function (full) {
-						return function (event) {
-							toClipboard(full);
-						};
-					})(msg)
-				);
+				m.symbol.addEventListener("click", () => {
+					toClipboard(msg);
+				});
 			} else addMessage("print", msg);
-			interpreter!.flush();
+			interpreter.flush();
 		};
-		interpreter.service.alert = function (msg) {
-			return new Promise((resolve, reject) => {
-				let dlg = tgui.msgBox({
-					title: "",
-					prompt: msg,
-					buttons: [{ text: "Okay", isDefault: true }],
-					enterConfirms: true,
-					onClose: () => {
-						resolve(null);
-						return false;
-					},
-				});
-			});
-		};
-		interpreter.service.confirm = function (msg) {
-			return new Promise((resolve, reject) => {
-				let value = false;
-				let dlg = tgui.msgBox({
-					title: "Question",
-					prompt: msg,
-					icon: tgui.msgBoxQuestion,
-					buttons: [
-						{
-							text: "Yes",
-							isDefault: true,
-							onClick: () => {
-								value = true;
-								return false;
-							},
-						},
-						{
-							text: "No",
-							isDefault: false,
-							onClick: () => {
-								value = false;
-								return false;
-							},
-						},
-					],
-					enterConfirms: true,
-					onClose: () => {
-						resolve(value);
-						return false;
-					},
-				});
-			});
-		};
-		interpreter.service.prompt = function (msg) {
-			return new Promise((resolve, reject) => {
-				let input = tgui.createElement({
-					type: "input",
-					classname: "ide-prompt-input",
-					properties: { type: "text" },
-				});
-				let value: string | null = null;
-				let dlg = tgui.createModal({
-					title: "Input",
-					scalesize: [0.2, 0.15],
-					minsize: [400, 250],
-					buttons: [
-						{
-							text: "Okay",
-							isDefault: true,
-							onClick: () => {
-								value = input.value;
-								return false;
-							},
-						},
-						{
-							text: "Cancel",
-							isDefault: false,
-							onClick: () => {
-								return false;
-							},
-						},
-					],
-					enterConfirms: true,
-					onClose: () => {
-						resolve(value);
-						return false;
-					},
-				});
-				tgui.createElement({
-					type: "p",
-					parent: dlg.content,
-					text: msg,
-					style: {
-						"white-space": "pre-wrap", // do linebreaks
-					},
-				});
-				dlg.content.appendChild(input);
-				tgui.startModal(dlg);
-				input.focus();
-			});
-		};
-		interpreter.service.message = function (msg, filename, line, ch, href) {
-			if (typeof filename === "undefined") filename = null;
-			if (typeof line === "undefined") line = null;
-			if (typeof ch === "undefined") ch = null;
-			if (typeof href === "undefined") href = "";
+		interpreter.service.message = (
+			msg: string,
+			filename?: string,
+			line?: number,
+			ch?: number,
+			href?: string
+		) => {
 			addMessage("error", msg, filename, line, ch, href);
 		};
-		interpreter.service.statechanged = function (stop) {
+		interpreter.service.statechanged = (stop: boolean) => {
 			if (stop) utils.updateControls();
 			else utils.updateStatus();
-			if (interpreter!.status === "finished") {
+			if (interpreter.status === "finished") {
 				let ed = collection.getActiveEditor();
 				if (ed) ed.focus();
 			}
 		};
-		interpreter.service.breakpoint = function () {
-			utils.updateControls();
-		};
-		interpreter.service.turtle.dom = turtle;
-		interpreter.service.canvas.dom = canvas;
-		interpreter.eventnames["canvas.resize"] = true;
-		interpreter.eventnames["canvas.mousedown"] = true;
-		interpreter.eventnames["canvas.mouseup"] = true;
-		interpreter.eventnames["canvas.mousemove"] = true;
-		interpreter.eventnames["canvas.mouseout"] = true;
-		interpreter.eventnames["canvas.keydown"] = true;
-		interpreter.eventnames["canvas.keyup"] = true;
-		interpreter.eventnames["timer"] = true;
-		interpreter.reset();
 
-		let breakpointsMoved = false;
-		for (let ed of collection.getEditors()) {
-			// set and correct breakpoints
-			let br = ed.properties().breakpoints;
-			let a = new Array<number>();
-			for (let line of br) a.push(line + 1);
+		this.#turtle = createTurtle(turtleContainer, this.#controller.signal);
+		turtleContainer.replaceChildren(this.#turtle);
+		interpreter.service.turtle.dom = this.#turtle;
 
-			let result = interpreter.defineBreakpoints(a, ed.properties().name);
-			if (result !== null) {
-				for (let line of br)
-					if (!result.has(line))
-						ed.properties().toggleBreakpoint(line);
-				for (let line of result)
-					if (!br.has(line)) ed.properties().toggleBreakpoint(line);
-				breakpointsMoved = true;
-			}
-		}
+		this.#canvas = createCanvas(
+			interpreter,
+			canvasContainer,
+			this.#controller.signal
+		);
+		canvasContainer.replaceChildren(this.#canvas);
+		interpreter.service.canvas.dom = this.#canvas;
+	}
 
-		//		if (breakpointsMoved)
-		//		{
-		//			alert("Note: breakpoints were moved to valid locations");   // TODO: proper modal dialog!!!
-		//		}
+	run() {
+		// Start background execution and focus the canvas container for keyboard input
+		this.interpreter.run();
+		this.#canvas.parentElement!.focus();
+	}
+
+	destroy() {
+		this.#controller.abort();
+
+		this.interpreter.stopthread();
+
+		this.#turtle.remove();
+		this.#canvas.remove();
 	}
 }
 
@@ -396,8 +305,6 @@ export function create(container: HTMLElement, options?: any) {
 
 	if (!options)
 		options = { "export-button": true, "documentation-button": true };
-
-	let standalone = options.standalone;
 
 	tgui.releaseAllHotkeys();
 
@@ -673,23 +580,21 @@ export function create(container: HTMLElement, options?: any) {
 		classname: "editorcontainer",
 	});
 
-	if (!standalone) {
-		if (config && config.hasOwnProperty("open")) {
-			for (let filename of config.open) {
-				openEditorFromLocalStorage(filename, false);
-			}
+	if (config && config.hasOwnProperty("open")) {
+		for (let filename of config.open) {
+			openEditorFromLocalStorage(filename, false);
 		}
-		if (config && config.hasOwnProperty("active")) {
-			let ed = collection.getEditor(config.active);
-			if (ed) collection.setActiveEditor(ed, false);
-		}
-		if (config && config.hasOwnProperty("main")) {
-			runselector.value = config.main;
-		}
-		if (collection.getEditors().size === 0) {
-			const ed = openEditorFromLocalStorage("Main");
-			if (!ed) createEditorTab("Main");
-		}
+	}
+	if (config && config.hasOwnProperty("active")) {
+		let ed = collection.getEditor(config.active);
+		if (ed) collection.setActiveEditor(ed, false);
+	}
+	if (config && config.hasOwnProperty("main")) {
+		runselector.value = config.main;
+	}
+	if (collection.getEditors().size === 0) {
+		const ed = openEditorFromLocalStorage("Main");
+		if (!ed) createEditorTab("Main");
 	}
 
 	let panel_messages = tgui.createPanel({
@@ -752,59 +657,9 @@ export function create(container: HTMLElement, options?: any) {
 		fallbackState: "float",
 		icon: icons.turtle,
 	});
-	turtle = tgui.createElement({
-		type: "canvas",
-		parent: panel_turtle.content,
-		properties: { width: "600", height: "600" },
-		classname: "ide ide-turtle",
-	});
-	turtle.addEventListener("contextmenu", function (event) {
-		event.preventDefault();
-		return false;
-	});
-
-	// ensure that the turtle area remains square and centered
-	let makeSquare = function () {
-		let w = turtle.parentElement.offsetWidth;
-		let h = turtle.parentElement.offsetHeight;
-		let size = Math.min(w, h);
-		turtle.style.width = size + "px";
-		turtle.style.height = size + "px";
-		turtle.style.marginLeft =
-			(w > size ? Math.floor((w - size) / 2) : 0) + "px";
-		turtle.style.marginTop =
-			(h > size ? Math.floor((h - size) / 2) : 0) + "px";
-	};
-	panel_turtle.onArrange = makeSquare;
-	panel_turtle.onResize = makeSquare;
-
-	createTypedEvent = function (displayname, dict) {
-		if (!interpreter) throw new Error("[createTypedEvent] internal error");
-		let p = interpreter.program;
-		for (let idx = 10; idx < p.types.length; idx++) {
-			let t = p.types[idx];
-			if (t.displayname === displayname) {
-				// create the object without calling the constructor, considering default values, etc
-				let obj: any = { type: t, value: { a: [] } };
-				let n = {
-					type: p.types[Typeid.typeid_null],
-					value: { b: null },
-				};
-				for (let i = 0; i < t.objectsize; i++) obj.value.a.push(n);
-
-				// fill its attributes
-				for (let key in t.members) {
-					if (!dict.hasOwnProperty(key)) continue;
-					obj.value.a[t.members[key].id] = TScript.json2typed.call(
-						interpreter,
-						dict[key]
-					);
-				}
-				return obj;
-			}
-		}
-		throw new Error("[createTypedEvent] unknown type " + displayname);
-	};
+	turtleContainer = panel_turtle.content;
+	turtleContainer.style.alignContent = "center";
+	turtleContainer.style.textAlign = "center";
 
 	// prepare canvas output panel
 	let panel_canvas = tgui.createPanel({
@@ -812,170 +667,11 @@ export function create(container: HTMLElement, options?: any) {
 		title: "Canvas",
 		state: "icon",
 		fallbackState: "right",
-		onResize: function (w, h) {
-			if (!standalone && canvas) {
-				canvas.width = w;
-				canvas.height = h;
-			}
-			if (interpreter) {
-				let e: any = { width: w, height: h };
-				e = createTypedEvent("canvas.ResizeEvent", e);
-				interpreter.enqueueEvent("canvas.resize", e);
-			}
-		},
 		icon: icons.canvas,
-	});
-	canvas = tgui.createElement({
-		type: "canvas",
-		parent: panel_canvas.content,
-		properties: {
-			width: panel_canvas.content.clientWidth.toString(),
-			height: panel_canvas.content.clientHeight.toString(),
-		},
-		classname: "ide ide-canvas",
-	});
-	canvas.addEventListener("contextmenu", function (event) {
-		event.preventDefault();
-		return false;
 	});
 	panel_canvas.content.tabIndex = -1;
 	panel_canvas.size = [0, 0];
-	//	module.canvas.font_size = 16;
-	function buttonName(button) {
-		if (button === 0) return "left";
-		else if (button === 1) return "middle";
-		else return "right";
-	}
-	function buttonNames(buttons) {
-		let ret = new Array();
-		if (buttons & 1) ret.push("left");
-		if (buttons & 4) ret.push("middle");
-		if (buttons & 2) ret.push("right");
-		return ret;
-	}
-	let ctx = canvas.getContext("2d");
-	ctx.lineWidth = 1;
-	ctx.fillStyle = "#000";
-	ctx.strokeStyle = "#000";
-	ctx.font = "16px Helvetica";
-	ctx.textAlign = "left";
-	ctx.textBaseline = "top";
-	canvas.addEventListener("mousedown", function (event) {
-		if (
-			!interpreter ||
-			!interpreter.background ||
-			(interpreter.status != "running" &&
-				interpreter.status != "waiting" &&
-				interpreter.status != "dialog")
-		)
-			return;
-		let e: any = {
-			button: buttonName(event.button),
-			buttons: buttonNames(event.buttons),
-			shift: event.shiftKey,
-			control: event.ctrlKey,
-			alt: event.altKey,
-			meta: event.metaKey,
-		};
-		e = Object.assign(e, utils.relpos(canvas, event.pageX, event.pageY));
-		e = createTypedEvent("canvas.MouseButtonEvent", e);
-		interpreter.enqueueEvent("canvas.mousedown", e);
-	});
-	canvas.addEventListener("mouseup", function (event) {
-		if (
-			!interpreter ||
-			!interpreter.background ||
-			(interpreter.status != "running" &&
-				interpreter.status != "waiting" &&
-				interpreter.status != "dialog")
-		)
-			return;
-		let e: any = {
-			button: buttonName(event.button),
-			buttons: buttonNames(event.buttons),
-			shift: event.shiftKey,
-			control: event.ctrlKey,
-			alt: event.altKey,
-			meta: event.metaKey,
-		};
-		e = Object.assign(e, utils.relpos(canvas, event.pageX, event.pageY));
-		e = createTypedEvent("canvas.MouseButtonEvent", e);
-		interpreter.enqueueEvent("canvas.mouseup", e);
-	});
-	canvas.addEventListener("mousemove", function (event) {
-		if (
-			!interpreter ||
-			!interpreter.background ||
-			(interpreter.status != "running" &&
-				interpreter.status != "waiting" &&
-				interpreter.status != "dialog")
-		)
-			return;
-		let e: any = {
-			button: 0,
-			buttons: buttonNames(event.buttons),
-			shift: event.shiftKey,
-			control: event.ctrlKey,
-			alt: event.altKey,
-			meta: event.metaKey,
-		};
-		e = Object.assign(e, utils.relpos(canvas, event.pageX, event.pageY));
-		e = createTypedEvent("canvas.MouseMoveEvent", e);
-		interpreter.enqueueEvent("canvas.mousemove", e);
-	});
-	canvas.addEventListener("mouseout", function (event) {
-		if (
-			!interpreter ||
-			!interpreter.background ||
-			(interpreter.status != "running" &&
-				interpreter.status != "waiting" &&
-				interpreter.status != "dialog")
-		)
-			return;
-		let e = {
-			type: interpreter.program.types[Typeid.typeid_null],
-			value: { b: null },
-		};
-		interpreter.enqueueEvent("canvas.mouseout", e);
-	});
-	panel_canvas.content.addEventListener("keydown", function (event) {
-		if (
-			!interpreter ||
-			!interpreter.background ||
-			(interpreter.status != "running" &&
-				interpreter.status != "waiting" &&
-				interpreter.status != "dialog")
-		)
-			return;
-		let e: any = {
-			key: event.key,
-			shift: event.shiftKey,
-			control: event.ctrlKey,
-			alt: event.altKey,
-			meta: event.metaKey,
-		};
-		e = createTypedEvent("canvas.KeyboardEvent", e);
-		interpreter.enqueueEvent("canvas.keydown", e);
-	});
-	panel_canvas.content.addEventListener("keyup", function (event) {
-		if (
-			!interpreter ||
-			!interpreter.background ||
-			(interpreter.status != "running" &&
-				interpreter.status != "waiting" &&
-				interpreter.status != "dialog")
-		)
-			return;
-		let e: any = {
-			key: event.key,
-			shift: event.shiftKey,
-			control: event.ctrlKey,
-			alt: event.altKey,
-			meta: event.metaKey,
-		};
-		e = createTypedEvent("canvas.KeyboardEvent", e);
-		interpreter.enqueueEvent("canvas.keyup", e);
-	});
+	canvasContainer = panel_canvas.content;
 
 	let panel_tutorial = tgui.createPanel({
 		name: "tutorial",

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -3,7 +3,7 @@ import { get_function } from "../../lang/helpers/getParents";
 import { Typeid } from "../../lang/helpers/typeIds";
 import { createDefaultServices } from "../../lang/interpreter/defaultService";
 import { Interpreter } from "../../lang/interpreter/interpreter";
-import { Parser } from "../../lang/parser";
+import { parseProgram } from "../../lang/parser";
 import { toClipboard } from "../clipboard";
 import { icons } from "../icons";
 import * as tgui from "../tgui";
@@ -177,7 +177,7 @@ export function prepare_run(run_selection: string | null = null) {
 		main: run_selection ? run_selection : getRunSelection(),
 	};
 
-	let result = Parser.parse(toParse, parseOptions);
+	let result = parseProgram(toParse, parseOptions);
 	let program = result.program;
 	let errors = result.errors;
 	if (errors) {

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -191,10 +191,10 @@ export function prepare_run(run_selection: string | null = null) {
 					err.line +
 					": " +
 					err.message,
-				err.filename,
+				err.filename ?? undefined,
 				err.line,
 				err.ch,
-				err.href
+				err.type === "error" ? err.href : undefined
 			);
 		}
 	}

--- a/src/ide/elements/utils.ts
+++ b/src/ide/elements/utils.ts
@@ -2,7 +2,7 @@ import * as ide from ".";
 import { openEditorFromLocalStorage } from "./editor-tabs";
 import { programinfo } from "./programinfo";
 import { stackinfo } from "./stackinfo";
-import { Editor } from "../editor";
+import { Interpreter } from "../../lang/interpreter/interpreter";
 
 export const type2css = [
 	"ide-keyword",
@@ -103,18 +103,5 @@ export function setCursorPosition(line: number, ch: number, name: string) {
 	ed.scrollIntoView();
 }
 
-//export function makeMarker() {
-//	let marker = document.createElement("span");
-//	marker.style.color = "#a00";
-//	marker.innerHTML = "\u25CF";
-//	return marker;
-//}
-//
-export function relpos(element, x, y) {
-	while (element) {
-		x -= element.offsetLeft;
-		y -= element.offsetTop;
-		element = element.offsetParent;
-	}
-	return { x: x, y: y };
-}
+export const interpreterEnded = (interpreter: Interpreter) =>
+	interpreter.status === "finished" || interpreter.status === "error";

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -1,5 +1,4 @@
 import { ErrorHelper } from "./lang/errors/ErrorHelper";
-import { defaultOptions } from "./lang/helpers/options";
 import { Typeid } from "./lang/helpers/typeIds";
 import { createDefaultServices } from "./lang/interpreter/defaultService";
 import { Interpreter as _Interpreter } from "./lang/interpreter/interpreter";
@@ -34,7 +33,7 @@ export const mul32 = TScript.mul32;
 export const mod = TScript.mod;
 export const order = TScript.order;
 export const parse = function (code) {
-	return Parser.parse(code, defaultOptions);
+	return Parser.parse(code);
 };
 export const previewValue = TScript.previewValue;
 export const typed2json = TScript.typed2json;

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -3,7 +3,7 @@ import { Typeid } from "./lang/helpers/typeIds";
 import { createDefaultServices } from "./lang/interpreter/defaultService";
 import { Interpreter as _Interpreter } from "./lang/interpreter/interpreter";
 import { Lexer } from "./lang/parser/lexer";
-import { Parser } from "./lang/parser";
+import { parseProgramFromString } from "./lang/parser";
 import { TScript } from "./lang";
 import { Version } from "./lang/version";
 import { evaluation as _evaluation } from "./eval";
@@ -32,9 +32,7 @@ export const json2typed = TScript.json2typed;
 export const mul32 = TScript.mul32;
 export const mod = TScript.mod;
 export const order = TScript.order;
-export const parse = function (code) {
-	return Parser.parse(code);
-};
+export const parse = parseProgramFromString;
 export const previewValue = TScript.previewValue;
 export const typed2json = TScript.typed2json;
 

--- a/src/lang/helpers/options.ts
+++ b/src/lang/helpers/options.ts
@@ -1,8 +1,0 @@
-export class Options {
-	public checkstyle: boolean = false;
-	public maxstacksize: number = 10000;
-
-	public constructor() {}
-}
-
-export const defaultOptions = new Options();

--- a/src/lang/helpers/sims.ts
+++ b/src/lang/helpers/sims.ts
@@ -1,15 +1,14 @@
-export function simfalse() {
-	return false;
-}
+import { SimFn } from "../interpreter/program-elements";
 
-export function simtrue() {
-	return true;
-}
+export const simfalse: SimFn = () => false;
 
-export function callsim() {
+/** Used for PEs that always complete after their first instruction */
+export const simtrue: SimFn = () => true;
+
+export const callsim: SimFn = function () {
 	let frame = this.stack[this.stack.length - 1];
 	let pe = frame.pe[frame.pe.length - 1];
 	let ip = frame.ip[frame.ip.length - 1];
 	let n = pe.arguments.length;
 	return ip === n + 1;
-}
+};

--- a/src/lang/helpers/steps.ts
+++ b/src/lang/helpers/steps.ts
@@ -1,7 +1,7 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
+import { Interpreter, InterpreterOptions } from "../interpreter/interpreter";
 import { TScript } from "..";
 import { Typeid } from "./typeIds";
-import { Options } from "../helpers/options";
 import { copyconstant } from "../interpreter/interpreter_helper";
 
 // step function of all constants
@@ -73,7 +73,7 @@ export function constructorstep() {
 }
 
 // step function of function calls
-export function callstep(options: Options) {
+export function callstep(this: Interpreter) {
 	let frame = this.stack[this.stack.length - 1];
 	let pe = frame.pe[frame.pe.length - 1];
 	let ip = frame.ip[frame.ip.length - 1];
@@ -229,7 +229,7 @@ export function callstep(options: Options) {
 			if (f.value.b.hasOwnProperty("enclosed"))
 				frame.enclosed = f.value.b.enclosed;
 			this.stack.push(frame);
-			if (this.stack.length >= options.maxstacksize)
+			if (this.stack.length >= this.maxStackSize)
 				ErrorHelper.error("/logic/le-1", [], this.stack);
 		}
 		return true;

--- a/src/lang/helpers/steps.ts
+++ b/src/lang/helpers/steps.ts
@@ -1,21 +1,21 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
-import { Interpreter, InterpreterOptions } from "../interpreter/interpreter";
 import { TScript } from "..";
 import { Typeid } from "./typeIds";
 import { copyconstant } from "../interpreter/interpreter_helper";
+import { StepFn } from "../interpreter/program-elements";
 
-// step function of all constants
-export function constantstep() {
+/** step function of all constants */
+export const constantstep: StepFn = function () {
 	let frame = this.stack[this.stack.length - 1];
 	let pe = frame.pe[frame.pe.length - 1];
 	frame.temporaries.push(copyconstant.call(this, pe.typedvalue));
 	frame.pe.pop();
 	frame.ip.pop();
 	return false;
-}
+};
 
-// step function of most scopes, including global scope and functions
-export function scopestep() {
+/** step function of most scopes, including global scope and functions */
+export const scopestep: StepFn = function () {
 	let frame = this.stack[this.stack.length - 1];
 	let pe = frame.pe[frame.pe.length - 1];
 	let ip = frame.ip[frame.ip.length - 1];
@@ -42,10 +42,10 @@ export function scopestep() {
 			return false;
 		} else return false;
 	}
-}
+};
 
-// step function of constructors
-export function constructorstep() {
+/** step function of constructors */
+export const constructorstep: StepFn = function () {
 	let frame = this.stack[this.stack.length - 1];
 	let pe = frame.pe[frame.pe.length - 1];
 	let ip = frame.ip[frame.ip.length - 1];
@@ -70,10 +70,10 @@ export function constructorstep() {
 		this.stack.pop();
 		return false;
 	}
-}
+};
 
-// step function of function calls
-export function callstep(this: Interpreter) {
+/** step function of function calls */
+export const callstep: StepFn = function () {
 	let frame = this.stack[this.stack.length - 1];
 	let pe = frame.pe[frame.pe.length - 1];
 	let ip = frame.ip[frame.ip.length - 1];
@@ -238,4 +238,4 @@ export function callstep(this: Interpreter) {
 		frame.ip.pop();
 		return false;
 	}
-}
+};

--- a/src/lang/interpreter/interpreter_helper.ts
+++ b/src/lang/interpreter/interpreter_helper.ts
@@ -1,9 +1,6 @@
-import {
-	binary_operator_impl,
-	left_unary_operator_impl,
-} from "../parser/parser_helper";
-import { simfalse } from "../helpers/sims";
 import { Typeid } from "../helpers/typeIds";
+import { ParserState } from "../parser";
+import { Breakpoint } from "./program-elements";
 
 export function deepcopy(value, excludekeys) {
 	if (typeof excludekeys === "undefined") excludekeys = {};
@@ -48,26 +45,27 @@ export function copyconstant(constant) {
 
 // Create a program element of type breakpoint.
 // The breakpoint is initially inactive.
-export function create_breakpoint(parent, state) {
+export function create_breakpoint(
+	parent: Breakpoint["parent"],
+	state: ParserState
+): Breakpoint {
 	let active = false;
-	let obj = {
+	return {
 		petype: "breakpoint",
 		parent: parent,
 		line: state.line,
 		where: state.get(),
-		active: function () {
-			return active;
-		},
-		set: function () {
+		active: () => active,
+		set() {
 			active = true;
 		},
-		clear: function () {
+		clear() {
 			active = false;
 		},
-		toggle: function () {
+		toggle() {
 			active = !active;
 		},
-		step: function () {
+		step() {
 			let frame = this.stack[this.stack.length - 1];
 			if (active) {
 				this.interrupt();
@@ -79,5 +77,4 @@ export function create_breakpoint(parent, state) {
 		},
 		sim: () => active,
 	};
-	return obj;
 }

--- a/src/lang/interpreter/program-elements.ts
+++ b/src/lang/interpreter/program-elements.ts
@@ -1,0 +1,62 @@
+import { ParserPosition } from "../parser";
+import { Interpreter } from "./interpreter";
+
+interface ProgramElementBase<Type extends string> {
+	readonly petype: Type;
+
+	/** The position where this program element starts in the source code */
+	where?: ParserPosition;
+
+	/**
+	 * Execute this program element
+	 *
+	 * @returns whether the program element is done. If false, it must be called again with an incremented instruction pointer.
+	 */
+	step(this: Interpreter): boolean;
+
+	/**
+	 * Determines whether the program element would be done after the next call to {@link step}.
+	 *
+	 * This controls when the debugger stops when stepping through a program.
+	 * Since the debugger wants to stop just before the PE's last instruction,
+	 * it halts when this method returns true.
+	 *
+	 * Some program elements don't want the debugger to halt on them and always return false
+	 * (e.g. by using `simfalse`).
+	 */
+	sim(this: Interpreter): boolean;
+}
+
+export type StepFn = ProgramElementBase<any>["step"];
+export type SimFn = ProgramElementBase<any>["sim"];
+
+/** like a main function, but with more stuff */
+export interface ProgramRoot extends ProgramElementBase<"global scope"> {
+	/** children in the abstract syntax tree */
+	children: any[];
+	/** top of the hierarchy */
+	parent: null;
+	/** sequence of commands */
+	commands: any[];
+	/** array of all types */
+	types: any[];
+	/** names of all global things */
+	names: Record<string, any>;
+	/** mapping of index to name */
+	variables: string[];
+	/** mapping of line numbers to breakpoints (some lines do not have breakpoints) */
+	breakpoints: Record<string, Record<number, Breakpoint>>;
+	/** total number of lines in the program = maximal line number */
+	lines: number;
+}
+
+export interface Breakpoint extends ProgramElementBase<"breakpoint"> {
+	parent: ProgramElementBase<any>;
+	where: ParserPosition;
+	line: number;
+	/** @returns whether the breakpoint is active */
+	active(): boolean;
+	set(): void;
+	clear(): void;
+	toggle(): void;
+}

--- a/src/lang/parser/index.ts
+++ b/src/lang/parser/index.ts
@@ -1,5 +1,6 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
 import { create_breakpoint } from "../interpreter/interpreter_helper";
+import { ProgramRoot } from "../interpreter/program-elements";
 import { core } from "../tscript-lib/core";
 import { lib_canvas } from "../tscript-lib/lib-canvas";
 import { lib_math } from "../tscript-lib/lib-math";
@@ -42,7 +43,7 @@ type ParseErrorOrWarning = ParseError | ParseWarning;
 
 export interface ParserState extends ParserPosition {
 	/** program tree to be built during parsing */
-	program: any;
+	program: ProgramRoot;
 
 	/** current source code */
 	source: string;
@@ -153,7 +154,8 @@ export interface ParseInput {
 }
 
 export interface ParseResult {
-	program: any;
+	program: ProgramRoot | null;
+	/** non-empty if {@link program} is null */
 	errors: ParseErrorOrWarning[];
 }
 
@@ -332,22 +334,22 @@ function compilerPass(state: ParserState, passname: string) {
 }
 
 /** creates the initial program structure */
-const createEmptyProgram = (): any => ({
-	petype: "global scope", // like a main function, but with more stuff
-	children: new Array(), // children in the abstract syntax tree
+export const createEmptyProgram = (): ProgramRoot => ({
+	petype: "global scope",
+	children: [],
 	parent: null, // top of the hierarchy
-	commands: [], // sequence of commands
-	types: [], // array of all types
-	names: {}, // names of all global things
-	variables: [], // mapping of index to name
-	breakpoints: {}, // mapping of line numbers (preceded by '#') to breakpoints (some lines do not have breakpoints)
-	lines: 0, // total number of lines in the program = maximal line number
+	commands: [],
+	types: [],
+	names: {},
+	variables: [],
+	breakpoints: {},
+	lines: 0,
 	step: scopestep, // execute all commands within the scope
 	sim: simfalse, // simulate commands
 });
 
 const createParserState = (
-	program: any,
+	program: ProgramRoot,
 	errors: ParseErrorOrWarning[]
 ): ParserState => ({
 	program,

--- a/src/lang/parser/index.ts
+++ b/src/lang/parser/index.ts
@@ -9,7 +9,6 @@ import { scopestep } from "../helpers/steps";
 import { simfalse } from "../helpers/sims";
 import { parse_statement_or_declaration } from "./parse_statementordeclaration";
 import { parse_include } from "./parse_include";
-import { defaultOptions, Options } from "../helpers/options";
 
 export interface ParserPosition {
 	/** filename or null */
@@ -139,6 +138,15 @@ export interface ParserState extends ParserPosition {
 	skip(this: ParserState): void;
 }
 
+export interface ParseOptions {
+	/** @default false */
+	checkstyle: boolean;
+}
+
+export const defaultParseOptions: ParseOptions = {
+	checkstyle: false,
+};
+
 export type ParseInput =
 	| { documents: Record<string, string>; main: string }
 	| string;
@@ -151,7 +159,7 @@ export interface ParseResult {
 export class Parser {
 	public static parse(
 		toParse: ParseInput,
-		options: Options = defaultOptions
+		options: ParseOptions = defaultParseOptions
 	): ParseResult {
 		// create the initial program structure
 		let program: any = {
@@ -166,7 +174,6 @@ export class Parser {
 			lines: 0, // total number of lines in the program = maximal line number
 			step: scopestep, // execute all commands within the scope
 			sim: simfalse, // simulate commands
-			options: options, // make the options available to the interpreter
 		};
 
 		const documents =

--- a/src/lang/parser/lexer.ts
+++ b/src/lang/parser/lexer.ts
@@ -5,7 +5,31 @@
 // input stream. It handles composite operators properly.
 //
 
+import { ParserPosition, ParserState } from ".";
 import { Options } from "../helpers/options";
+
+interface LexerTokenObj<T extends string, V> {
+	type: T;
+	value: V;
+	code: string;
+	line: number;
+}
+
+export type Keyword = keyof typeof Lexer.keywords;
+
+export function isKeyword(str: string): str is Keyword {
+	return Object.hasOwn(Lexer.keywords, str);
+}
+
+export type LexerToken =
+	| LexerTokenObj<"end-of-file", "">
+	| LexerTokenObj<"keyword", Keyword>
+	| LexerTokenObj<"identifier", string>
+	| LexerTokenObj<"real" | "integer", number>
+	| LexerTokenObj<"string", string>
+	| LexerTokenObj<"operator", string>
+	| LexerTokenObj<"grouping", string>
+	| LexerTokenObj<"delimiter", string>;
 
 export class Lexer {
 	public static keywords = {
@@ -68,10 +92,10 @@ export class Lexer {
 	// since string tokens can take on any value. Therefore a token must
 	// always be tested for its type first, and then for a certain value.
 	public static get_token(
-		state,
+		state: ParserState,
 		options: Options,
 		peek: boolean | undefined = undefined
-	) {
+	): LexerToken {
 		peek = typeof peek !== "undefined" ? peek : false;
 		let where = peek ? state.get() : false;
 		state.skip();
@@ -81,7 +105,7 @@ export class Lexer {
 			return { type: "end-of-file", value: "", code: "", line: line };
 
 		let indent = state.indentation();
-		let tok: any = null;
+		let tok: LexerToken;
 
 		let c = state.current();
 		if ((c >= "A" && c <= "Z") || (c >= "a" && c <= "z") || c === "_") {
@@ -100,21 +124,14 @@ export class Lexer {
 				else break;
 			}
 			let value = state.source.substring(start, state.pos);
-			if (where) state.set(where);
-			else state.skip();
-			tok = {
-				type: Lexer.keywords.hasOwnProperty(value)
-					? "keyword"
-					: "identifier",
-				value: value,
-				code: value,
-				line: line,
-			};
+			tok = isKeyword(value)
+				? { type: "keyword", value, code: value, line }
+				: { type: "identifier", value, code: value, line };
 		} else if (c >= "0" && c <= "9") {
 			// parse a number, integer or float
 			let start = state.pos;
 			let digits = "0123456789";
-			let type = "integer";
+			let type: "real" | "integer" = "integer";
 			while (!state.eof() && digits.indexOf(state.current()) >= 0)
 				state.advance();
 			if (!state.eof()) {
@@ -153,8 +170,6 @@ export class Lexer {
 			}
 			let value = state.source.substring(start, state.pos);
 			let n = parseFloat(value);
-			if (where) state.set(where);
-			else state.skip();
 			tok = { type: type, value: n, code: value, line: line };
 		} else if (c === '"') {
 			// parse string token
@@ -200,14 +215,13 @@ export class Lexer {
 					state.advance();
 				}
 			}
-			if (where) state.set(where);
-			else state.skip();
 			tok = { type: "string", value: value, code: code, line: line };
 		} else {
 			// all the rest, including operators
 			state.advance();
+			let op: string | undefined;
 			if (Lexer.operators.indexOf(c) >= 0) {
-				let op = c;
+				op = c;
 				if (state.current() === "/" && c === "/") {
 					state.advance();
 					op += "/";
@@ -216,22 +230,21 @@ export class Lexer {
 					state.advance();
 					op += "=";
 				}
-				if (op !== "!") {
-					if (where) state.set(where);
-					else state.skip();
-					tok = { type: "operator", value: op, code: op, line: line };
-				}
 			}
-			if (tok === null) {
-				let type: any = null;
+
+			if (op && op !== "!") {
+				tok = { type: "operator", value: op, code: op, line: line };
+			} else {
+				let type: "grouping" | "delimiter";
 				if (Lexer.groupings.indexOf(c) >= 0) type = "grouping";
 				else if (Lexer.delimiters.indexOf(c) >= 0) type = "delimiter";
 				else state.error("/syntax/se-5", [c]);
-				if (where) state.set(where);
-				else state.skip();
 				tok = { type: type, value: c, code: c, line: line };
 			}
 		}
+
+		if (where) state.set(where);
+		else state.skip();
 
 		if (options.checkstyle && !state.builtin()) {
 			// check for indentation problems
@@ -259,5 +272,5 @@ export class Lexer {
 		return tok;
 	}
 
-	public static before_token = {}; // state stored by get_token that can be restored with state.set()
+	public static before_token: ParserPosition; // state stored by get_token that can be restored with state.set()
 }

--- a/src/lang/parser/lexer.ts
+++ b/src/lang/parser/lexer.ts
@@ -5,8 +5,7 @@
 // input stream. It handles composite operators properly.
 //
 
-import { ParserPosition, ParserState } from ".";
-import { Options } from "../helpers/options";
+import { ParseOptions, ParserPosition, ParserState } from ".";
 
 interface LexerTokenObj<T extends string, V> {
 	type: T;
@@ -93,7 +92,7 @@ export class Lexer {
 	// always be tested for its type first, and then for a certain value.
 	public static get_token(
 		state: ParserState,
-		options: Options,
+		options: ParseOptions,
 		peek: boolean | undefined = undefined
 	): LexerToken {
 		peek = typeof peek !== "undefined" ? peek : false;

--- a/src/lang/parser/parse_assignment_or_expression.ts
+++ b/src/lang/parser/parse_assignment_or_expression.ts
@@ -3,13 +3,12 @@ import { assignments } from "./parser_helper";
 import { simfalse } from "../helpers/sims";
 import { parse_expression } from "./parse_expression";
 import { parse_lhs } from "./parse_lhs";
-import { Options } from "../helpers/options";
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 
 export function parse_assignment_or_expression(
 	state: ParserState,
 	parent,
-	options: Options
+	options: ParseOptions
 ) {
 	// try to parse an expression
 	let where = state.get();

--- a/src/lang/parser/parse_assignment_or_expression.ts
+++ b/src/lang/parser/parse_assignment_or_expression.ts
@@ -4,9 +4,10 @@ import { simfalse } from "../helpers/sims";
 import { parse_expression } from "./parse_expression";
 import { parse_lhs } from "./parse_lhs";
 import { Options } from "../helpers/options";
+import { ParserState } from ".";
 
 export function parse_assignment_or_expression(
-	state,
+	state: ParserState,
 	parent,
 	options: Options
 ) {

--- a/src/lang/parser/parse_break.ts
+++ b/src/lang/parser/parse_break.ts
@@ -2,8 +2,9 @@ import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
 import { simtrue } from "../helpers/sims";
 import { Options } from "../helpers/options";
+import { ParserState } from ".";
 
-export function parse_break(state, parent, options: Options) {
+export function parse_break(state: ParserState, parent, options: Options) {
 	// handle "break" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_break.ts
+++ b/src/lang/parser/parse_break.ts
@@ -1,10 +1,9 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
 import { simtrue } from "../helpers/sims";
-import { Options } from "../helpers/options";
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 
-export function parse_break(state: ParserState, parent, options: Options) {
+export function parse_break(state: ParserState, parent, options: ParseOptions) {
 	// handle "break" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_call.ts
+++ b/src/lang/parser/parse_call.ts
@@ -6,12 +6,16 @@ import { simfalse, callsim } from "../helpers/sims";
 import { callstep } from "../helpers/steps";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
-import { Options } from "../helpers/options";
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 
 // Parse the argument list of a function call.
 // The expression to the left of the parenthesis is provided as #base.
-export function parse_call(state: ParserState, parent, base, options: Options) {
+export function parse_call(
+	state: ParserState,
+	parent,
+	base,
+	options: ParseOptions
+) {
 	// parse the opening parenthesis, which is assumed to be already detected
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_call.ts
+++ b/src/lang/parser/parse_call.ts
@@ -1,6 +1,5 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
-import { copyconstant } from "../interpreter/interpreter_helper";
 import { get_type } from "../helpers/getParents";
 import { TScript } from "..";
 import { simfalse, callsim } from "../helpers/sims";
@@ -8,10 +7,11 @@ import { callstep } from "../helpers/steps";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
 import { Options } from "../helpers/options";
+import { ParserState } from ".";
 
 // Parse the argument list of a function call.
 // The expression to the left of the parenthesis is provided as #base.
-export function parse_call(state, parent, base, options: Options) {
+export function parse_call(state: ParserState, parent, base, options: Options) {
 	// parse the opening parenthesis, which is assumed to be already detected
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_class.ts
+++ b/src/lang/parser/parse_class.ts
@@ -11,9 +11,10 @@ import { parse_var } from "./parse_var";
 import { parse_expression, is_name } from "./parse_expression";
 import { parse_constructor } from "./parse_constructor";
 import { Options } from "../helpers/options";
+import { ParserState } from ".";
 
 // Parse a class declaration.
-export function parse_class(state, parent, options: Options) {
+export function parse_class(state: ParserState, parent, options: Options) {
 	// handle the "class" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_class.ts
+++ b/src/lang/parser/parse_class.ts
@@ -10,11 +10,10 @@ import { parse_use } from "./parse_use";
 import { parse_var } from "./parse_var";
 import { parse_expression, is_name } from "./parse_expression";
 import { parse_constructor } from "./parse_constructor";
-import { Options } from "../helpers/options";
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 
 // Parse a class declaration.
-export function parse_class(state: ParserState, parent, options: Options) {
+export function parse_class(state: ParserState, parent, options: ParseOptions) {
 	// handle the "class" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_class.ts
+++ b/src/lang/parser/parse_class.ts
@@ -1,5 +1,5 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
-import { Lexer } from "./lexer";
+import { Keyword, Lexer } from "./lexer";
 import { get_program } from "../helpers/getParents";
 import { constantstep } from "../helpers/steps";
 import { Typeid } from "../helpers/typeIds";
@@ -194,7 +194,7 @@ export function parse_class(state, parent, options: Options) {
 	state.indent.push(-1 - token.line);
 
 	// parse the class body
-	let access = null;
+	let access: Keyword | null = null;
 	while (true) {
 		// check for end-of-class-body
 		token = Lexer.get_token(state, options, true);

--- a/src/lang/parser/parse_constructor.ts
+++ b/src/lang/parser/parse_constructor.ts
@@ -7,14 +7,13 @@ import { constantstep, constructorstep, callstep } from "../helpers/steps";
 import { simfalse, callsim } from "../helpers/sims";
 import { parse_expression } from "./parse_expression";
 import { parse_statement_or_declaration } from "./parse_statementordeclaration";
-import { Options } from "../helpers/options";
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 
 // Parse a constructor declaration.
 export function parse_constructor(
 	state: ParserState,
 	parent,
-	options: Options
+	options: ParseOptions
 ) {
 	// check that the parent is indeed a type
 	ErrorHelper.assert(

--- a/src/lang/parser/parse_constructor.ts
+++ b/src/lang/parser/parse_constructor.ts
@@ -8,9 +8,14 @@ import { simfalse, callsim } from "../helpers/sims";
 import { parse_expression } from "./parse_expression";
 import { parse_statement_or_declaration } from "./parse_statementordeclaration";
 import { Options } from "../helpers/options";
+import { ParserState } from ".";
 
 // Parse a constructor declaration.
-export function parse_constructor(state, parent, options: Options) {
+export function parse_constructor(
+	state: ParserState,
+	parent,
+	options: Options
+) {
 	// check that the parent is indeed a type
 	ErrorHelper.assert(
 		parent.petype === "type",
@@ -175,14 +180,14 @@ export function parse_constructor(state, parent, options: Options) {
 	}
 
 	// replace the function body with built-in functionality
-	if (func.commands.length === 0) {
+	if (func.commands.length === 0 && state.impl) {
 		let fullname = new Array();
 		let p = func;
 		while (p.parent) {
 			fullname.unshift(p.name);
 			p = p.parent;
 		}
-		let d = state.impl;
+		let d: any = state.impl;
 		for (let i = 0; i < fullname.length; i++) {
 			if (d.hasOwnProperty(fullname[i])) d = d[fullname[i]];
 			else {

--- a/src/lang/parser/parse_continue.ts
+++ b/src/lang/parser/parse_continue.ts
@@ -1,10 +1,13 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
 import { simtrue } from "../helpers/sims";
-import { Options } from "../helpers/options";
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 
-export function parse_continue(state: ParserState, parent, options: Options) {
+export function parse_continue(
+	state: ParserState,
+	parent,
+	options: ParseOptions
+) {
 	// handle "continue" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_continue.ts
+++ b/src/lang/parser/parse_continue.ts
@@ -2,8 +2,9 @@ import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
 import { simtrue } from "../helpers/sims";
 import { Options } from "../helpers/options";
+import { ParserState } from ".";
 
-export function parse_continue(state, parent, options: Options) {
+export function parse_continue(state: ParserState, parent, options: Options) {
 	// handle "continue" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_declaration.ts
+++ b/src/lang/parser/parse_declaration.ts
@@ -5,10 +5,15 @@ import { parse_function } from "./parse_function";
 import { parse_namespace } from "./parse_namespace";
 import { parse_use } from "./parse_use";
 import { parse_var } from "./parse_var";
+import { ParserState } from ".";
 
 // Parse var, function, class, or namespace
 // The function return null if no declaration is found.
-export function parse_declaration(state, parent, options: Options) {
+export function parse_declaration(
+	state: ParserState,
+	parent,
+	options: Options
+) {
 	let kw = peek_keyword(state);
 
 	if (kw === "var") return parse_var(state, parent, options);

--- a/src/lang/parser/parse_declaration.ts
+++ b/src/lang/parser/parse_declaration.ts
@@ -1,18 +1,17 @@
-import { Options } from "../helpers/options";
 import { peek_keyword } from "./parser_helper";
 import { parse_class } from "./parse_class";
 import { parse_function } from "./parse_function";
 import { parse_namespace } from "./parse_namespace";
 import { parse_use } from "./parse_use";
 import { parse_var } from "./parse_var";
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 
 // Parse var, function, class, or namespace
 // The function return null if no declaration is found.
 export function parse_declaration(
 	state: ParserState,
 	parent,
-	options: Options
+	options: ParseOptions
 ) {
 	let kw = peek_keyword(state);
 

--- a/src/lang/parser/parse_dowhile.ts
+++ b/src/lang/parser/parse_dowhile.ts
@@ -5,8 +5,9 @@ import { TScript } from "..";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
 import { parse_statement } from "./parse_statement";
+import { ParserState } from ".";
 
-export function parse_dowhile(state, parent, options: Options) {
+export function parse_dowhile(state: ParserState, parent, options: Options) {
 	// handle "do" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_dowhile.ts
+++ b/src/lang/parser/parse_dowhile.ts
@@ -1,13 +1,16 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
-import { Options } from "../helpers/options";
 import { TScript } from "..";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
 import { parse_statement } from "./parse_statement";
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 
-export function parse_dowhile(state: ParserState, parent, options: Options) {
+export function parse_dowhile(
+	state: ParserState,
+	parent,
+	options: ParseOptions
+) {
 	// handle "do" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_expression.ts
+++ b/src/lang/parser/parse_expression.ts
@@ -15,9 +15,10 @@ import { Typeid } from "../helpers/typeIds";
 import { parse_call } from "./parse_call";
 import { parse_statement_or_declaration } from "./parse_statementordeclaration";
 import { resolve_name } from "./parse_fn";
+import { ParserState } from ".";
 
 export function parse_expression(
-	state,
+	state: ParserState,
 	parent,
 	options,
 	lhs: boolean = false,

--- a/src/lang/parser/parse_expression.ts
+++ b/src/lang/parser/parse_expression.ts
@@ -96,7 +96,7 @@ export function parse_expression(
 			ex.sim = simfalse;
 		} else if (token.type === "integer") {
 			// constant
-			let v = parseFloat(token.value);
+			let v = token.value;
 			if (v > 2147483647) {
 				state.set(Lexer.before_token);
 				state.error("/syntax/se-23");
@@ -111,7 +111,7 @@ export function parse_expression(
 			ex.sim = simfalse;
 		} else if (token.type === "real") {
 			// constant
-			let v = parseFloat(token.value);
+			let v = token.value;
 			ex.petype = "constant";
 			ex.typedvalue = {
 				type: get_program(parent).types[Typeid.typeid_real],

--- a/src/lang/parser/parse_fn.ts
+++ b/src/lang/parser/parse_fn.ts
@@ -1,26 +1,9 @@
-import { ErrorHelper } from "../errors/ErrorHelper";
-import { Lexer } from "./lexer";
-import {
-	assignments,
-	binary_operator_impl,
-	binary_operator_precedence,
-	left_unary_operator_impl,
-	left_unary_operator_precedence,
-	peek_keyword,
-} from "./parser_helper";
-import { create_breakpoint } from "../interpreter/interpreter_helper";
-import {
-	get_context,
-	get_function,
-	get_program,
-	get_type,
-} from "../helpers/getParents";
-import { scopestep } from "../helpers/steps";
-import { simfalse, simtrue } from "../helpers/sims";
+import { ParserState } from ".";
 import { TScript } from "..";
-import { Typeid } from "../helpers/typeIds";
+import { ErrorHelper } from "../errors/ErrorHelper";
+import { get_context, get_function, get_type } from "../helpers/getParents";
 
-export function resolve_name(state, name, parent, errorname) {
+export function resolve_name(state: ParserState, name, parent, errorname) {
 	// prepare a generic "not defined" error
 	let error = "/name/ne-5";
 	let arg = [errorname, name];
@@ -125,7 +108,7 @@ export function resolve_namespace_name(name, parent) {
 	}
 }
 
-export function resolve_names(pe, state) {
+export function resolve_names(pe, state: ParserState) {
 	if (pe.hasOwnProperty("resolve")) {
 		var temp = state.get();
 		state.set(pe.where);

--- a/src/lang/parser/parse_for.ts
+++ b/src/lang/parser/parse_for.ts
@@ -5,8 +5,9 @@ import { TScript } from "..";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression, is_name } from "./parse_expression";
 import { parse_statement } from "./parse_statement";
+import { ParserState } from ".";
 
-export function parse_for(state, parent, options) {
+export function parse_for(state: ParserState, parent, options) {
 	// handle "for" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_function.ts
+++ b/src/lang/parser/parse_function.ts
@@ -1,14 +1,14 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
-import { TScript } from "..";
 import { scopestep } from "../helpers/steps";
 import { simfalse } from "../helpers/sims";
 import { parse_expression } from "./parse_expression";
 import { parse_statement_or_declaration } from "./parse_statementordeclaration";
+import { ParserState } from ".";
 
 // Parse a function declaration.
 export function parse_function(
-	state,
+	state: ParserState,
 	parent,
 	options,
 	petype: any = undefined
@@ -155,14 +155,14 @@ export function parse_function(
 	}
 
 	// replace the function body with built-in functionality
-	if (func.commands.length === 0) {
+	if (func.commands.length === 0 && state.impl) {
 		let fullname = new Array();
 		let p = func;
 		while (p.parent) {
 			fullname.unshift(p.name);
 			p = p.parent;
 		}
-		let d = state.impl;
+		let d: any = state.impl;
 		for (let i = 0; i < fullname.length; i++) {
 			if (d.hasOwnProperty(fullname[i])) d = d[fullname[i]];
 			else {

--- a/src/lang/parser/parse_ifthenelse.ts
+++ b/src/lang/parser/parse_ifthenelse.ts
@@ -6,8 +6,9 @@ import { simfalse } from "../helpers/sims";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
 import { parse_statement } from "./parse_statement";
+import { ParserState } from ".";
 
-export function parse_ifthenelse(state, parent, options) {
+export function parse_ifthenelse(state: ParserState, parent, options) {
 	// handle "if" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_include.ts
+++ b/src/lang/parser/parse_include.ts
@@ -1,10 +1,20 @@
+import { ParserState } from ".";
 import { ErrorHelper } from "../errors/ErrorHelper";
 import { Options } from "../helpers/options";
 import { Lexer } from "./lexer";
 import { peek_keyword } from "./parser_helper";
 
+interface IncludeResult {
+	filename: string;
+	source: string;
+}
+
 // return the included string in case of an include statement and null otherwise
-export function parse_include(state, parent, options: Options) {
+export function parse_include(
+	state: ParserState,
+	parent,
+	options: Options
+): IncludeResult | null {
 	// handle "include" keyword
 	if (peek_keyword(state) !== "include") return null;
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_include.ts
+++ b/src/lang/parser/parse_include.ts
@@ -1,6 +1,5 @@
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 import { ErrorHelper } from "../errors/ErrorHelper";
-import { Options } from "../helpers/options";
 import { Lexer } from "./lexer";
 import { peek_keyword } from "./parser_helper";
 
@@ -13,7 +12,7 @@ interface IncludeResult {
 export function parse_include(
 	state: ParserState,
 	parent,
-	options: Options
+	options: ParseOptions
 ): IncludeResult | null {
 	// handle "include" keyword
 	if (peek_keyword(state) !== "include") return null;

--- a/src/lang/parser/parse_lhs.ts
+++ b/src/lang/parser/parse_lhs.ts
@@ -4,8 +4,9 @@ import { TScript } from "..";
 import { simtrue } from "../helpers/sims";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
+import { ParserState } from ".";
 
-export function parse_lhs(state, parent, options) {
+export function parse_lhs(state: ParserState, parent, options) {
 	// parse the LHS as an expression
 	let ex = parse_expression(state, parent, options, true);
 	let back = ex.passResolveBack;

--- a/src/lang/parser/parse_namespace.ts
+++ b/src/lang/parser/parse_namespace.ts
@@ -1,12 +1,12 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
-import { TScript } from "..";
 import { scopestep } from "../helpers/steps";
 import { simfalse } from "../helpers/sims";
 import { parse_statement_or_declaration } from "./parse_statementordeclaration";
+import { ParserState } from ".";
 
 // Parse a namespace declaration.
-export function parse_namespace(state, parent, options) {
+export function parse_namespace(state: ParserState, parent, options) {
 	// handle "namespace" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_return.ts
+++ b/src/lang/parser/parse_return.ts
@@ -3,8 +3,9 @@ import { Lexer } from "./lexer";
 import { get_function } from "../helpers/getParents";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
+import { ParserState } from ".";
 
-export function parse_return(state, parent, options) {
+export function parse_return(state: ParserState, parent, options) {
 	// handle "return" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_statement.ts
+++ b/src/lang/parser/parse_statement.ts
@@ -13,10 +13,11 @@ import { parse_statement_or_declaration } from "./parse_statementordeclaration";
 import { parse_throw } from "./parse_throw";
 import { parse_trycatch } from "./parse_trycatch";
 import { parse_whiledo } from "./parse_whiledo";
+import { ParserState } from ".";
 
 // Parse a single statement, or a group of statements.
 export function parse_statement(
-	state,
+	state: ParserState,
 	parent,
 	options,
 	var_allowed: boolean = false

--- a/src/lang/parser/parse_statementordeclaration.ts
+++ b/src/lang/parser/parse_statementordeclaration.ts
@@ -1,8 +1,13 @@
+import { ParserState } from ".";
 import { create_breakpoint } from "../interpreter/interpreter_helper";
 import { parse_declaration } from "./parse_declaration";
 import { parse_statement } from "./parse_statement";
 
-export function parse_statement_or_declaration(state, parent, options) {
+export function parse_statement_or_declaration(
+	state: ParserState,
+	parent,
+	options
+) {
 	function markAsBuiltin(value) {
 		if (Array.isArray(value)) {
 			for (let i = 0; i < value.length; i++) markAsBuiltin(value[i]);
@@ -24,7 +29,7 @@ export function parse_statement_or_declaration(state, parent, options) {
 		}
 	}
 
-	if (!state.builtin()) {
+	if (!state.builtin() && state.filename) {
 		state.skip();
 
 		const breakpoints = state.program.breakpoints[state.filename];

--- a/src/lang/parser/parse_throw.ts
+++ b/src/lang/parser/parse_throw.ts
@@ -2,8 +2,9 @@ import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
 import { TScript } from "..";
 import { parse_expression } from "./parse_expression";
+import { ParserState } from ".";
 
-export function parse_throw(state, parent, options) {
+export function parse_throw(state: ParserState, parent, options) {
 	// handle "throw" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_trycatch.ts
+++ b/src/lang/parser/parse_trycatch.ts
@@ -3,8 +3,9 @@ import { Lexer } from "./lexer";
 import { get_function } from "../helpers/getParents";
 import { simfalse } from "../helpers/sims";
 import { parse_statement } from "./parse_statement";
+import { ParserState } from ".";
 
-export function parse_trycatch(state, parent, options) {
+export function parse_trycatch(state: ParserState, parent, options) {
 	// handle "try" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_use.ts
+++ b/src/lang/parser/parse_use.ts
@@ -2,9 +2,10 @@ import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
 import { peek_keyword } from "./parser_helper";
 import { parse_expression, is_name } from "./parse_expression";
+import { ParserState } from ".";
 
 // Parse a "use" declaration.
-export function parse_use(state, parent, options) {
+export function parse_use(state: ParserState, parent, options) {
 	// handle "use" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parse_var.ts
+++ b/src/lang/parser/parse_var.ts
@@ -4,8 +4,7 @@ import { get_function } from "../helpers/getParents";
 import { simfalse } from "../helpers/sims";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
-import { Options } from "../helpers/options";
-import { ParserState } from ".";
+import { ParseOptions, ParserState } from ".";
 
 // Parse a "var" statement. Even for multiple variables it is treated as
 // a single statement. The variables are placed into the container,
@@ -13,7 +12,7 @@ import { ParserState } from ".";
 export function parse_var(
 	state: ParserState,
 	parent,
-	options: Options,
+	options: ParseOptions,
 	container: any = undefined
 ) {
 	container =

--- a/src/lang/parser/parse_var.ts
+++ b/src/lang/parser/parse_var.ts
@@ -1,17 +1,17 @@
 import { ErrorHelper } from "../errors/ErrorHelper";
 import { Lexer } from "./lexer";
 import { get_function } from "../helpers/getParents";
-import { TScript } from "..";
 import { simfalse } from "../helpers/sims";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
 import { Options } from "../helpers/options";
+import { ParserState } from ".";
 
 // Parse a "var" statement. Even for multiple variables it is treated as
 // a single statement. The variables are placed into the container,
 // which defaults to the enclosing function or global scope.
 export function parse_var(
-	state,
+	state: ParserState,
 	parent,
 	options: Options,
 	container: any = undefined

--- a/src/lang/parser/parse_whiledo.ts
+++ b/src/lang/parser/parse_whiledo.ts
@@ -4,8 +4,9 @@ import { TScript } from "..";
 import { Typeid } from "../helpers/typeIds";
 import { parse_expression } from "./parse_expression";
 import { parse_statement } from "./parse_statement";
+import { ParserState } from ".";
 
-export function parse_whiledo(state, parent, options) {
+export function parse_whiledo(state: ParserState, parent, options) {
 	// handle "while" keyword
 	let where = state.get();
 	let token = Lexer.get_token(state, options);

--- a/src/lang/parser/parser_helper.ts
+++ b/src/lang/parser/parser_helper.ts
@@ -1,6 +1,7 @@
-import { Lexer } from "./lexer";
+import { ParserState } from ".";
 import { TScript } from "..";
 import { Typeid } from "../helpers/typeIds";
+import { isKeyword, Keyword } from "./lexer";
 
 ///////////////////////////////////////////////////////////
 // The parser parses source code and translates the program
@@ -422,7 +423,7 @@ export const binary_operator_impl = {
 // This function checks whether the next token is a keyword. If so then
 // the keyword is returned without altering the state, otherwise the
 // function returns the empty string.
-export function peek_keyword(state) {
+export function peek_keyword(state: ParserState): Keyword | "" {
 	let where = state.get();
 	state.skip();
 	if (state.eof()) return "";
@@ -445,7 +446,7 @@ export function peek_keyword(state) {
 		}
 		let value = state.source.substring(start, state.pos);
 		state.set(where);
-		if (Lexer.keywords.hasOwnProperty(value)) return value;
+		if (isKeyword(value)) return value;
 		else return "";
 	} else {
 		state.set(where);

--- a/src/lang/tests/testRunner.ts
+++ b/src/lang/tests/testRunner.ts
@@ -2,7 +2,7 @@ import { ErrorHelper } from "../errors/ErrorHelper";
 import { Typeid } from "../helpers/typeIds";
 import { createDefaultServices } from "../interpreter/defaultService";
 import { Interpreter } from "../interpreter/interpreter";
-import { Parser } from "../parser";
+import { Parser, ParseResult } from "../parser";
 import { TScript } from "..";
 import { TscriptTest } from "./tests";
 
@@ -56,7 +56,7 @@ export class TestRunner {
 		let result = new Array();
 
 		// parse the program
-		let parsed;
+		let parsed: ParseResult;
 		try {
 			parsed = Parser.parse(test.code);
 			if (test.parseOnly) {
@@ -223,14 +223,15 @@ export class TestRunner {
 	// returns true if the program had parse errors
 	private static checkParseErrorsMatch(
 		test: TscriptTest,
-		parsed: any,
+		parsed: ParseResult,
 		cb: Callback
 	): boolean {
 		if (parsed.errors !== null && parsed.errors.length > 0) {
 			let errors = new Array();
 			for (let i = 0; i < parsed.errors.length; i++) {
 				let err = parsed.errors[i];
-				errors.push({ type: "error", href: err.href });
+				if (err.type === "error")
+					errors.push({ type: "error", href: err.href });
 			}
 			errors.push("parsing failed");
 			TestRunner.check(test, errors, cb);

--- a/src/lang/tests/testRunner.ts
+++ b/src/lang/tests/testRunner.ts
@@ -2,7 +2,7 @@ import { ErrorHelper } from "../errors/ErrorHelper";
 import { Typeid } from "../helpers/typeIds";
 import { createDefaultServices } from "../interpreter/defaultService";
 import { Interpreter } from "../interpreter/interpreter";
-import { Parser, ParseResult } from "../parser";
+import { parseProgramFromString, ParseResult } from "../parser";
 import { TScript } from "..";
 import { TscriptTest } from "./tests";
 
@@ -58,7 +58,7 @@ export class TestRunner {
 		// parse the program
 		let parsed: ParseResult;
 		try {
-			parsed = Parser.parse(test.code);
+			parsed = parseProgramFromString(test.code);
 			if (test.parseOnly) {
 				cb.suc(test);
 				return;

--- a/src/lang/tests/testRunner.ts
+++ b/src/lang/tests/testRunner.ts
@@ -127,7 +127,7 @@ export class TestRunner {
 			s.turtle.dom.width = 600;
 		}
 
-		let interpreter = new Interpreter(parsed.program, service);
+		let interpreter = new Interpreter(parsed.program!, service);
 		interpreter.eventnames["canvas.resize"] = true;
 		interpreter.eventnames["canvas.mousedown"] = true;
 		interpreter.eventnames["canvas.mouseup"] = true;

--- a/src/lang/tscript-lib/core.ts
+++ b/src/lang/tscript-lib/core.ts
@@ -4,7 +4,7 @@ import { Typeid } from "../helpers/typeIds";
 import { Version } from "../version";
 import { simfalse, simtrue } from "../helpers/sims";
 import { tscript_core } from "./core.tscript";
-import { Interpreter } from "../interpreter/interpreter";
+import { Interpreter, StackFrame } from "../interpreter/interpreter";
 
 export const core = {
 	source: tscript_core,
@@ -552,7 +552,7 @@ export const core = {
 						let params = [state.src[state.lb], state.src[state.rb]];
 						if (comp.hasOwnProperty("enclosed"))
 							params = comp.enclosed.concat(params);
-						let newframe = {
+						let newframe: StackFrame = {
 							pe: [comp.func],
 							ip: [-1],
 							temporaries: [],
@@ -1349,7 +1349,7 @@ export const core = {
 									params = handler.enclosed.concat(params);
 
 								// create a new stack frame with the function arguments as local variables
-								let frame = {
+								let frame: StackFrame = {
 									pe: [handler.func],
 									ip: [-1],
 									temporaries: [],

--- a/src/lang/tscript-lib/core.ts
+++ b/src/lang/tscript-lib/core.ts
@@ -4,6 +4,7 @@ import { Typeid } from "../helpers/typeIds";
 import { Version } from "../version";
 import { simfalse, simtrue } from "../helpers/sims";
 import { tscript_core } from "./core.tscript";
+import { Interpreter } from "../interpreter/interpreter";
 
 export const core = {
 	source: tscript_core,
@@ -479,7 +480,7 @@ export const core = {
 				};
 			},
 			sort: {
-				step: function () {
+				step(this: Interpreter) {
 					// iterative merge sort
 					let frame = this.stack[this.stack.length - 1];
 					let pe = frame.pe[frame.pe.length - 1];
@@ -564,7 +565,7 @@ export const core = {
 						if (comp.hasOwnProperty("enclosed"))
 							newframe.enclosed = comp.enclosed;
 						this.stack.push(newframe);
-						if (this.stack.length >= this.options.maxstacksize)
+						if (this.stack.length >= this.maxStackSize)
 							this.error("/logic/le-1");
 						return false;
 					} else if (ip === 2) {
@@ -1306,7 +1307,7 @@ export const core = {
 				this.eventmode = true;
 				this.stack[this.stack.length - 1].pe.push({
 					// this cumbersome inner command is necessary since function.step is expected to always return false
-					step: function () {
+					step(this: Interpreter) {
 						let frame = this.stack[this.stack.length - 1];
 						if (!this.eventmode) {
 							// return from event mode
@@ -1361,10 +1362,7 @@ export const core = {
 								if (handler.hasOwnProperty("enclosed"))
 									frame.enclosed = handler.enclosed;
 								this.stack.push(frame);
-								if (
-									this.stack.length >=
-									this.options.maxstacksize
-								)
+								if (this.stack.length >= this.maxStackSize)
 									this.error("/logic/le-1");
 							}
 						}
@@ -1377,7 +1375,7 @@ export const core = {
 			},
 			sim: simfalse,
 		},
-		quitEventMode: function (result) {
+		quitEventMode(this: Interpreter, result: any) {
 			if (!this.eventmode) this.error("/logic/le-3");
 			this.eventmode = false;
 			this.eventmodeReturnValue = result;


### PR DESCRIPTION
Currently, standalone exports initialize the entire IDE and open Editors for each included file, just so the interpreter can load the code.

This PR does the following:

- The last commit decouples the standalone page from the IDE by separating common logic for the creation of the interpreter and canvases
  - Canvases for the turtle/canvas namespaces are now newly created for each run and removed with the interpreter. They handle resizes by observing their container element.
  - Objects belonging to the interpreter (the canvases) are grouped in a new class `InterpreterSession`
- Loading of included files is moved from the parser into a callback
- The remaining commits add (a lot of) types and refactors to enable this

## Accidental Bugfixes/Features

The parser previously loaded included files from localStorage. In environments where localStorage is not available, using the `include` statement would've probably lead to a crash (NodeJS, exam evaluation?).

To export a program using includes, it was previously necessary to open all included files in editors (and I couldn't find any documentation on this). Now, the export command is able to automatically determine which files are included and only adds those to the output.

## Regarding the Merge

Since this PR touches a lot of files, I split some changes into multiple commits and gave (hopefully) good descriptions on what is changed. Is there a specific reason why you like to squash PRs? If you'd like, I could still combine some of these commits into one.