### PR TITLE
Reduce asynchronous UI code caused by TreeControl

### DIFF
--- a/src/ide/doc.ts
+++ b/src/ide/doc.ts
@@ -664,7 +664,7 @@ export const doc = (function () {
 		return [node, parent, parentpath, index];
 	}
 
-	module.setpath = async function (path) {
+	module.setpath = function (path) {
 		if (!path) path = "";
 		if (path.length > 0 && path[0] == "#") path = path.substr(1);
 
@@ -712,7 +712,7 @@ export const doc = (function () {
 			module.dom_content.innerHTML = html;
 			module.dom_content.scrollTop = 0;
 			docpath = "";
-			await doctree!.update(docinfo);
+			doctree!.update(docinfo);
 		} else {
 			try {
 				let data = getnode(path);
@@ -775,7 +775,7 @@ export const doc = (function () {
 				module.dom_content.innerHTML = prepare(html);
 				module.dom_content.scrollTop = 0;
 				docpath = path;
-				await doctree!.update(docinfo);
+				doctree!.update(docinfo);
 
 				let pres = document.getElementsByTagName("pre");
 				for (let i = 0; i < pres.length; i++) {
@@ -846,7 +846,7 @@ export const doc = (function () {
 	module.dom_content = null;
 	module.embedded = false;
 
-	module.create = async function (container, options) {
+	module.create = function (container, options) {
 		if (!options)
 			options = {
 				embedded: false,
@@ -900,13 +900,10 @@ export const doc = (function () {
 		// display the version
 		window.setTimeout(function (event) {
 			module.dom_version.innerHTML = Version.full();
-			module.dom_version.addEventListener(
-				"click",
-				async function (event) {
-					if (module.embedded) await module.setpath("/legal");
-					else navigate("?doc=/legal");
-				}
-			);
+			module.dom_version.addEventListener("click", function (event) {
+				if (module.embedded) module.setpath("/legal");
+				else navigate("?doc=/legal");
+			});
 		}, 100);
 
 		// prepare the error sub-tree of the documentation tree
@@ -933,38 +930,33 @@ export const doc = (function () {
 		doctree = new tgui.TreeControl({
 			parent: module.dom_tree,
 			info: docinfo,
-			nodeclick: async function (event, value, id) {
-				if (module.embedded) await module.setpath(id);
+			nodeclick: function (event, value, id) {
+				if (module.embedded) module.setpath(id);
 				else navigate("?doc=" + id);
 			},
 		});
-		await doctree.update();
+		doctree.update();
 
 		// make the search field functional
 		searchengine.clear();
 		initsearch("", doc); // index the docs
-		module.dom_searchtext.addEventListener(
-			"keypress",
-			async function (event) {
-				if (event.key != "Enter") return;
+		module.dom_searchtext.addEventListener("keypress", function (event) {
+			if (event.key != "Enter") return;
 
-				if (module.embedded) {
-					let keys = searchengine.tokenize(
-						module.dom_searchtext.value
-					);
-					let h = "#search";
-					for (let i = 0; i < keys.length; i++) h += "/" + keys[i];
-					window.sessionStorage.setItem("docpath", h);
-					await module.setpath(h);
-				} else {
-					const searchParams = new URLSearchParams({
-						doc: "search",
-						q: module.dom_searchtext.value,
-					});
-					navigate("?" + searchParams.toString());
-				}
+			if (module.embedded) {
+				let keys = searchengine.tokenize(module.dom_searchtext.value);
+				let h = "#search";
+				for (let i = 0; i < keys.length; i++) h += "/" + keys[i];
+				window.sessionStorage.setItem("docpath", h);
+				module.setpath(h);
+			} else {
+				const searchParams = new URLSearchParams({
+					doc: "search",
+					q: module.dom_searchtext.value,
+				});
+				navigate("?" + searchParams.toString());
 			}
-		);
+		});
 
 		// check all internal links
 		checklinks(doc, "");
@@ -972,9 +964,9 @@ export const doc = (function () {
 		if (options.embedded) {
 			let path = window.sessionStorage.getItem("docpath");
 			if (!path) path = "#";
-			await module.setpath(path);
+			module.setpath(path);
 
-			document.addEventListener("click", async function (event) {
+			document.addEventListener("click", function (event) {
 				let target: any = event.target || event.srcElement;
 				if (target.tagName === "A") {
 					let href = target.getAttribute("href");
@@ -982,7 +974,7 @@ export const doc = (function () {
 					if (!href.startsWith("?doc=")) return true;
 					href = href.replace("?doc=", "#");
 					window.sessionStorage.setItem("docpath", href);
-					await module.setpath(href);
+					module.setpath(href);
 					event.preventDefault();
 					event.stopPropagation();
 					event.stopImmediatePropagation();

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -91,9 +91,9 @@ export let buttons: any = [
 	},
 ];
 
-async function cmd_reset() {
+function cmd_reset() {
 	ide.clear();
-	await updateControls();
+	updateControls();
 }
 
 /**
@@ -309,7 +309,7 @@ function cmd_load() {
 		}
 
 		openEditorFromLocalStorage(name);
-		return updateControls().then(() => undefined);
+		updateControls();
 	});
 }
 
@@ -362,7 +362,7 @@ export function cmd_upload() {
 					} else {
 						openEditorFromLocalStorage(filename);
 					}
-					await updateControls();
+					updateControls();
 				}
 			},
 		},

--- a/src/ide/elements/dialogs.ts
+++ b/src/ide/elements/dialogs.ts
@@ -362,7 +362,7 @@ export function fileDlg(
 	filename: string,
 	allowNewFilename: boolean,
 	confirmText: string,
-	onOkay: (filename: string) => any | Promise<any>
+	onOkay: (filename: string) => any
 ) {
 	// 10px horizontal spacing
 	//  7px vertical spacing
@@ -374,11 +374,11 @@ export function fileDlg(
 	files.sort();
 
 	// return true on failure, that is when the dialog should be kept open
-	let onFileConfirmation = async function () {
+	let onFileConfirmation = function () {
 		let fn = name.value;
 		if (fn != "") {
 			if (allowNewFilename || files.indexOf(fn) >= 0) {
-				await onOkay(fn);
+				onOkay(fn);
 				return false; // close dialog
 			}
 		}

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -110,7 +110,7 @@ export function addMessage(
 			msg.ide_filename = filename;
 			msg.ide_line = line;
 			msg.ide_ch = ch;
-			msg.addEventListener("click", async function (event) {
+			msg.addEventListener("click", function (event) {
 				utils.setCursorPosition(
 					event.target.ide_line,
 					event.target.ide_ch,
@@ -120,7 +120,7 @@ export function addMessage(
 					interpreter &&
 					(interpreter.status != "running" || !interpreter.background)
 				) {
-					await utils.updateControls();
+					utils.updateControls();
 				}
 				return false;
 			});
@@ -262,8 +262,8 @@ class InterpreterSession {
 		) => {
 			addMessage("error", msg, filename, line, ch, href);
 		};
-		interpreter.service.statechanged = async (stop: boolean) => {
-			if (stop) await utils.updateControls();
+		interpreter.service.statechanged = (stop: boolean) => {
+			if (stop) utils.updateControls();
 			else utils.updateStatus();
 			if (interpreter.status === "finished") {
 				let ed = collection.getActiveEditor();
@@ -300,7 +300,7 @@ class InterpreterSession {
 	}
 }
 
-export async function create(container: HTMLElement, options?: any) {
+export function create(container: HTMLElement, options?: any) {
 	let config = loadConfig();
 
 	if (!options)

--- a/src/ide/elements/utils.ts
+++ b/src/ide/elements/utils.ts
@@ -60,7 +60,7 @@ export function updateStatus() {
 /**
  * update the controls to reflect the interpreter state
  */
-export async function updateControls() {
+export function updateControls() {
 	// move the cursor in the source code
 	if (ide.interpreter) {
 		if (ide.interpreter.stack.length > 0) {
@@ -81,10 +81,10 @@ export async function updateControls() {
 	}
 
 	// show the current stack state
-	await ide.stacktree!.update(stackinfo);
+	ide.stacktree!.update(stackinfo);
 
 	// show the current program tree
-	await ide.programtree!.update(programinfo);
+	ide.programtree!.update(programinfo);
 
 	updateStatus();
 }

--- a/src/ide/index.ts
+++ b/src/ide/index.ts
@@ -21,7 +21,7 @@ import "./css-dark/ide.css";
 import "./css-dark/tgui.css";
 import "./css-dark/tutorial.css";
 
-window.addEventListener("load", async () => {
+window.addEventListener("load", () => {
 	const container = document.getElementById("ide-container")!;
 	container.replaceChildren(); // empties the container
 
@@ -41,7 +41,7 @@ window.addEventListener("load", async () => {
 		currentUrl = redirectUrl;
 	}
 
-	await initializeNavigation(currentUrl, container, (url) => {
+	initializeNavigation(currentUrl, container, (url) => {
 		if (url.searchParams.has("doc")) return DocumentationPageController;
 		return IDEPageController;
 	});
@@ -69,17 +69,10 @@ function translateLegacyURL(currentUrl: URL): URL | null {
 }
 
 class IDEPageController implements IPageController {
-	container: HTMLElement;
-	location: URL;
 	constructor(container: HTMLElement, location: URL) {
-		this.container = container;
-		this.location = location;
-	}
+		elements.create(container);
 
-	async init() {
-		await elements.create(this.container);
-
-		const loadUrl = this.location.searchParams.get("load");
+		const loadUrl = location.searchParams.get("load");
 		if (loadUrl) loadScriptFromUrl(loadUrl);
 	}
 
@@ -101,16 +94,9 @@ async function loadScriptFromUrl(url: string): Promise<void> {
 }
 
 class DocumentationPageController implements IPageController {
-	container: HTMLElement;
-	location: URL;
 	constructor(container: HTMLElement, location: URL) {
-		this.container = container;
-		this.location = location;
-	}
-
-	async init() {
-		await doc.create(this.container);
-		this.showPage(this.location.searchParams);
+		doc.create(container);
+		this.showPage(location.searchParams);
 	}
 
 	navigate(newLocation: URL): boolean {

--- a/src/ide/navigation.ts
+++ b/src/ide/navigation.ts
@@ -1,5 +1,4 @@
 export interface IPageController {
-	init(): Promise<void>;
 	navigate?(newLocation: URL): boolean;
 	checkUnsavedChanges?(): boolean;
 }
@@ -20,18 +19,17 @@ let pageResolver: PageResolver | undefined;
  * @param container the container element to place the page in
  * @param resolver a function mapping URLs to their controller classes
  */
-export async function initializeNavigation(
+export function initializeNavigation(
 	url: URL,
 	container: HTMLElement,
 	resolver: PageResolver
-): Promise<void> {
+): void {
 	if (pageResolver) return;
 
 	const controllerType = resolver(url);
 	if (!controllerType) return;
 
 	currentController = new controllerType(container, url);
-	await currentController.init();
 	pageResolver = resolver;
 
 	window.addEventListener("popstate", () => {

--- a/src/ide/tgui/hotkeys.ts
+++ b/src/ide/tgui/hotkeys.ts
@@ -7,10 +7,7 @@ let hotkeyElement = null;
 /**
  * register a new hotkey, check for conflicts
  */
-export function setHotkey(
-	hotkey: string,
-	handler: (event: MouseEvent) => Promise<any> | any
-) {
+export function setHotkey(hotkey: string, handler: (event: MouseEvent) => any) {
 	if (!hotkey) return;
 	hotkey = normalizeHotkey(hotkey);
 	if (hotkeys.hasOwnProperty(hotkey))
@@ -52,13 +49,13 @@ export function normalizeHotkey(hotkey) {
 }
 
 /** register a global key listener for hotkey events */
-document.addEventListener("keydown", async function (event) {
+document.addEventListener("keydown", function (event) {
 	if (modal.length > 0) {
 		// redirect key events to the topmost dialog
 		let dlg = modal[modal.length - 1];
 		if (!dlg.onKeyDownOverride) {
 			if (event.key == "Escape") {
-				return await dlg.handleClose(event);
+				return dlg.handleClose(event);
 			}
 			if (event.key == "F1") {
 				return dlg.handleHelp?.(event);
@@ -67,7 +64,7 @@ document.addEventListener("keydown", async function (event) {
 				dlg.hasOwnProperty("enterConfirms") &&
 				dlg.enterConfirms
 			) {
-				return await dlg.handleDefault(event);
+				return dlg.handleDefault(event);
 			}
 		}
 
@@ -87,7 +84,7 @@ document.addEventListener("keydown", async function (event) {
 
 		// handle global hotkeys
 		if (hotkeys.hasOwnProperty(key)) {
-			await hotkeys[key](event);
+			hotkeys[key](event);
 			event.preventDefault();
 			event.stopPropagation();
 			return false;

--- a/src/ide/tgui/modals.ts
+++ b/src/ide/tgui/modals.ts
@@ -92,14 +92,14 @@ export function createModal(description: ModalDescription): Modal {
 	// dialog  -- the DOM object of the dialog contents
 	let control: any = Object.assign({}, description);
 
-	let handleButton = async function (event, button) {
+	let handleButton = function (event, button) {
 		if (event) {
 			event.preventDefault();
 			event.stopPropagation();
 		}
 
 		if (button && button.onClick) {
-			let keepOpen = await button.onClick();
+			let keepOpen = button.onClick();
 			if (keepOpen) return false;
 		}
 
@@ -184,7 +184,7 @@ export function createModal(description: ModalDescription): Modal {
 		}
 	});
 
-	control.handleClose = async (event) => await handleButton(event, null);
+	control.handleClose = (event) => handleButton(event, null);
 	// createTitleBar defined below
 	control.titlebar = createTitleBar(
 		dialog,
@@ -218,8 +218,7 @@ export function createModal(description: ModalDescription): Modal {
 		});
 
 		for (let button of control.buttons) {
-			let eventHandler = async (event) =>
-				await handleButton(event, button);
+			let eventHandler = (event) => handleButton(event, button);
 
 			if (button.isDefault) control.handleDefault = eventHandler;
 
@@ -287,8 +286,8 @@ export function createModal(description: ModalDescription): Modal {
 
 		let close = createButton({
 			parent: titlebar,
-			click: async function () {
-				return await handleClose(null);
+			click: function () {
+				return handleClose(null);
 			},
 			width: 20,
 			height: 20,


### PR DESCRIPTION
@ole0811sch: If I understand correctly, you need the info callback to be able to return promises.

I think that the UI code should have as few async paths as possible, since it increases the potential for bugs.
For example, I'm not sure whether it would be fine if the async version of `updateControls` is called while a previous call hasn't completed yet.

To mitigate this, I reverted the callers of `TreeControl#update` to be synchronous. Instead, `TreeControl` now manages asynchronous updates itself.

on `update(…)`:

- if no asynchronous update is running, a new one starts
- if there is one, `TreeControl` remembers to start a new one once the current has completed

**Note:** As before, there is no handling for errors that occur during the update

@TGlas: While I previously [advised against using private class members](https://github.com/TGlas/tscript/pull/96#discussion_r718310758), I've realized that I was totally wrong on the reasons. TypeScript compiles them away anyway, and ~3 years later, [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties#browser_compatibility) has changed as well. So it would still work if the compilation target was increased.

Are you fine with having both `private property` and `#property` in the project? Or should I stick to TypeScript's modifiers?