### PR TITLE
Implement file IDs for internal use

### DIFF
--- a/src/ide/elements/collection.ts
+++ b/src/ide/elements/collection.ts
@@ -5,7 +5,7 @@ import {
 	isLoadableFileID,
 	LoadableFileID,
 	splitFileIDAtColon,
-} from "../../lang/parser";
+} from "../../lang/parser/file_id";
 import { getResolvedTheme, subscribeOnThemeChange } from "../tgui";
 import { EditorController, NavigationRequest } from "./editor-controller";
 

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -1,6 +1,7 @@
 import * as ide from ".";
-import { ParseInput, parseProgram } from "../../lang/parser";
+import { parseProgram } from "../../lang/parser";
 import { icons } from "../icons";
+import { type StandaloneCode } from "../standalone";
 import * as tgui from "./../tgui";
 import {
 	confirmFileOverwrite,
@@ -135,12 +136,19 @@ async function cmd_step_out() {
 }
 
 export async function cmd_export() {
-	const parsedFiles = new Map<string, ParseInput>();
-	const parseInput = await ide.createParseInput(parsedFiles);
-	if (!parseInput) return;
+	const resolveEntryRes = await ide.createParseInput();
+	if (!resolveEntryRes) return;
 
 	// check that the code at least compiles
-	let result = await parseProgram(parseInput, parseOptions);
+	let result = await parseProgram(
+		resolveEntryRes.parseInput,
+		true,
+		parseOptions
+	);
+
+	// everything after that should ideally be synchronous
+	ide.clear();
+
 	let program = result.program;
 	let errors = result.errors;
 	if (errors && errors.length > 0) {
@@ -168,7 +176,7 @@ export async function cmd_export() {
 	}
 
 	// create a filename for the file download from the title
-	let title = parseInput.filename;
+	let title = resolveEntryRes.parseInput.filename;
 	let fn = "tscript-export";
 	if (
 		!fn.endsWith("html") &&
@@ -213,13 +221,15 @@ export async function cmd_export() {
 
 	tgui.startModal(dlg);
 
-	// escape the TScript source code; prepare it to reside inside an html document
-	let source = JSON.stringify({
-		documents: Object.fromEntries(
-			Array.from(parsedFiles.values(), (f) => [f.filename, f.source])
+	const standaloneCode: StandaloneCode = {
+		includeSourceResolutions: Object.fromEntries(
+			resolveEntryRes.includeSourceResolutions.entries()
 		),
-		main: parseInput.filename,
-	});
+		includeResolutions: resolveEntryRes.includeResolutions,
+		main: resolveEntryRes.parseInput.filename,
+	};
+	// escape the TScript source code; prepare it to reside inside an html document
+	let source = JSON.stringify(standaloneCode);
 
 	// obtain the page itself as a string
 	{

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -95,6 +95,11 @@ function cmd_reset() {
 	ide.clear();
 }
 
+export function existsActiveSession(): boolean {
+	let session = ide.interpreterSession;
+	return session !== null && !interpreterEnded(session.interpreter);
+}
+
 /**
  * Gets the active interpreter session or creates a new one if no program is running
  */
@@ -131,7 +136,7 @@ async function cmd_step_out() {
 
 export async function cmd_export() {
 	const parsedFiles = new Map<string, ParseInput>();
-	const parseInput = ide.createParseInput(parsedFiles);
+	const parseInput = await ide.createParseInput(parsedFiles);
 	if (!parseInput) return;
 
 	// check that the code at least compiles

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -1,8 +1,15 @@
 import * as ide from ".";
-import { parseProgram } from "../../lang/parser";
+import { ErrorHelper } from "../../lang/errors/ErrorHelper";
+import {
+	fileIDChangeNamespace,
+	fileIDToContextDependentFilename,
+	localstorageFileID,
+	parseProgram,
+} from "../../lang/parser";
 import { icons } from "../icons";
 import { type StandaloneCode } from "../standalone";
 import * as tgui from "./../tgui";
+import { msgBox } from "./../tgui";
 import {
 	confirmFileOverwrite,
 	fileDlg,
@@ -138,13 +145,10 @@ async function cmd_step_out() {
 export async function cmd_export() {
 	const resolveEntryRes = await ide.createParseInput();
 	if (!resolveEntryRes) return;
+	const [mainEntry, includeResolutions] = resolveEntryRes;
 
 	// check that the code at least compiles
-	let result = await parseProgram(
-		resolveEntryRes.parseInput,
-		true,
-		parseOptions
-	);
+	let result = await parseProgram(mainEntry, true, parseOptions);
 
 	// everything after that should ideally be synchronous
 	ide.clear();
@@ -156,12 +160,13 @@ export async function cmd_export() {
 			let err = errors[i];
 			ide.addMessage(
 				err.type,
-				err.type +
-					(err.filename ? " in file '" + err.filename + "'" : "") +
-					" in line " +
-					err.line +
-					": " +
-					err.message,
+				ErrorHelper.getLocatedErrorMsg(
+					err.type,
+					err.filename ?? undefined,
+					err.line,
+					err.message
+				),
+
 				err.filename ?? undefined,
 				err.line,
 				err.ch,
@@ -176,7 +181,10 @@ export async function cmd_export() {
 	}
 
 	// create a filename for the file download from the title
-	let title = resolveEntryRes.parseInput.filename;
+	const humandReadableFilename = fileIDToContextDependentFilename(
+		mainEntry.filename
+	);
+	let title = humandReadableFilename;
 	let fn = "tscript-export";
 	if (
 		!fn.endsWith("html") &&
@@ -223,10 +231,10 @@ export async function cmd_export() {
 
 	const standaloneCode: StandaloneCode = {
 		includeSourceResolutions: Object.fromEntries(
-			resolveEntryRes.includeSourceResolutions.entries()
+			includeResolutions.includeSourceResolutions.entries()
 		),
-		includeResolutions: resolveEntryRes.includeResolutions,
-		main: resolveEntryRes.parseInput.filename,
+		includeResolutions: includeResolutions.includeResolutions,
+		main: includeResolutions.main,
 	};
 	// escape the TScript source code; prepare it to reside inside an html document
 	let source = JSON.stringify(standaloneCode);
@@ -306,13 +314,14 @@ function cmd_new() {
 		const isSavedDoc =
 			localStorage.getItem("tscript.code." + name) !== null;
 
-		if (isSavedDoc || ide.collection.getEditor(name)) {
+		const fileID = localstorageFileID(name);
+		if (isSavedDoc || ide.collection.getEditor(fileID)) {
 			confirmFileOverwrite(name, () => {
 				// replace the existing file/editor
-				ide.collection.openEditorFromData(name, "");
+				ide.collection.openEditorFromData(fileID, "");
 			});
 		} else {
-			ide.collection.openEditorFromData(name, "");
+			ide.collection.openEditorFromData(fileID, "");
 		}
 
 		return false;
@@ -321,7 +330,7 @@ function cmd_new() {
 
 function cmd_load() {
 	fileDlg("Load file", "", false, "Load", (name) => {
-		ide.collection.openEditorFromFile(name);
+		ide.collection.openEditorFromFile(localstorageFileID(name));
 	});
 }
 
@@ -339,7 +348,7 @@ function cmd_save_as() {
 		true,
 		"Save",
 		(filename) => {
-			controller.saveAs(filename);
+			controller.saveAs(localstorageFileID(filename));
 		}
 	);
 }
@@ -369,7 +378,7 @@ export function cmd_upload() {
 export function cmd_download() {
 	const controller = ide.collection.activeEditor;
 	if (!controller) return;
-	const filename = controller.filename;
+	const filename = fileIDToContextDependentFilename(controller.filename);
 	const content = controller.editorView.text();
 
 	const link = tgui.createElement({

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -98,18 +98,18 @@ function cmd_reset() {
 /**
  * Gets the active interpreter session or creates a new one if no program is running
  */
-function getOrRestartSession() {
+async function getOrRestartSession() {
 	let session = ide.interpreterSession;
-	if (!session || interpreterEnded(session.interpreter)) {
+	if (session && !interpreterEnded(session.interpreter)) {
+		return session;
+	} else {
 		// (re-)start the interpreter
-		session = ide.prepareRun();
+		return await ide.prepareRun();
 	}
-
-	return session;
 }
 
-function cmd_run() {
-	getOrRestartSession()?.interpreter.run();
+async function cmd_run() {
+	(await getOrRestartSession())?.interpreter.run();
 }
 
 function cmd_interrupt() {
@@ -117,25 +117,25 @@ function cmd_interrupt() {
 	if (interpreter && !interpreterEnded(interpreter)) interpreter.interrupt();
 }
 
-function cmd_step_into() {
-	getOrRestartSession()?.interpreter.step_into();
+async function cmd_step_into() {
+	(await getOrRestartSession())?.interpreter.step_into();
 }
 
-function cmd_step_over() {
-	getOrRestartSession()?.interpreter.step_over();
+async function cmd_step_over() {
+	(await getOrRestartSession())?.interpreter.step_over();
 }
 
-function cmd_step_out() {
-	getOrRestartSession()?.interpreter.step_out();
+async function cmd_step_out() {
+	(await getOrRestartSession())?.interpreter.step_out();
 }
 
-export function cmd_export() {
+export async function cmd_export() {
 	const parsedFiles = new Map<string, ParseInput>();
 	const parseInput = ide.createParseInput(parsedFiles);
 	if (!parseInput) return;
 
 	// check that the code at least compiles
-	let result = parseProgram(parseInput, parseOptions);
+	let result = await parseProgram(parseInput, parseOptions);
 	let program = result.program;
 	let errors = result.errors;
 	if (errors && errors.length > 0) {

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -1,11 +1,11 @@
 import * as ide from ".";
 import { ErrorHelper } from "../../lang/errors/ErrorHelper";
+import { parseProgram } from "../../lang/parser";
 import {
 	fileIDChangeNamespace,
 	fileIDToContextDependentFilename,
 	localstorageFileID,
-	parseProgram,
-} from "../../lang/parser";
+} from "../../lang/parser/file_id";
 import { icons } from "../icons";
 import { type StandaloneCode } from "../standalone";
 import * as tgui from "./../tgui";

--- a/src/ide/elements/dialogs.ts
+++ b/src/ide/elements/dialogs.ts
@@ -1,4 +1,11 @@
-import { defaultParseOptions, ParseOptions } from "../../lang/parser";
+import {
+	FileID,
+	fileIDToHumanFriendly,
+	isLoadableFileID,
+	LoadableFileID,
+	defaultParseOptions,
+	ParseOptions,
+} from "../../lang/parser";
 import * as tgui from "./../tgui";
 import { buttons } from "./commands";
 import * as ide from "./index";
@@ -11,11 +18,11 @@ export let parseOptions: ParseOptions = defaultParseOptions;
  * When the document was not changed, or the user allows to discard the changes the function onConfirm is
  * called.
  */
-export function confirmFileDiscard(name: string, onConfirm: () => any) {
+export function confirmFileDiscard(name: FileID, onConfirm: () => any) {
 	tgui.msgBox({
 		prompt: "The document may have unsaved changes.\nDo you want to discard the code?",
 		icon: tgui.msgBoxQuestion,
-		title: name,
+		title: fileIDToHumanFriendly(name),
 		buttons: [
 			{ text: "Discard", onClick: onConfirm, isDefault: true },
 			{ text: "Cancel" },
@@ -38,14 +45,24 @@ export function confirmFileOverwrite(name: string, onConfirm: () => any) {
 	});
 }
 
+type Config = {
+	options: ParseOptions;
+	hotkeys: string[];
+	theme: tgui.ThemeConfiguration;
+	tabs: any;
+	open: LoadableFileID[];
+	main: FileID;
+	active: LoadableFileID | null;
+};
+
 /**
  * Load hotkeys & other settings
  */
 export function loadConfig() {
 	let str = localStorage.getItem("tscript.ide.config");
-	let config: any = null;
+	let config: Config | null = null;
 	if (str) {
-		config = JSON.parse(str);
+		config = JSON.parse(str) as Config;
 		if (config.hasOwnProperty("hotkeys")) {
 			let n = Math.min(buttons.length, config.hotkeys.length);
 			for (let i = 0; i < n; i++) {
@@ -72,12 +89,12 @@ export function loadConfig() {
  */
 export function saveConfig() {
 	const editorsState = ide.collection.getSerializedState();
-	let config: any = {
+	let config: Config = {
 		options: parseOptions,
 		hotkeys: [],
 		theme: tgui.getThemeConfig(),
 		tabs: ide.tab_config,
-		open: editorsState.open,
+		open: editorsState.open.filter(isLoadableFileID),
 		main: ide.getRunSelection(),
 		active: editorsState.active,
 	};

--- a/src/ide/elements/dialogs.ts
+++ b/src/ide/elements/dialogs.ts
@@ -4,6 +4,7 @@ import {
 	fileIDToHumanFriendly,
 	isLoadableFileID,
 	LoadableFileID,
+	localstorageFileID,
 } from "../../lang/parser/file_id";
 import * as tgui from "./../tgui";
 import { buttons } from "./commands";
@@ -518,11 +519,11 @@ export function fileDlg(
 	(allowNewFilename ? (name as any) : list).focus();
 	return dlg;
 
-	function deleteFile(filename) {
+	function deleteFile(filename: string) {
 		let index = files.indexOf(filename);
 		if (index >= 0) {
 			let onDelete = () => {
-				ide.collection.getEditor(filename)?.close();
+				ide.collection.getEditor(localstorageFileID(filename))?.close();
 				localStorage.removeItem("tscript.code." + filename);
 				files.splice(index, 1);
 				list.remove(index);

--- a/src/ide/elements/dialogs.ts
+++ b/src/ide/elements/dialogs.ts
@@ -1,11 +1,10 @@
+import { defaultParseOptions, ParseOptions } from "../../lang/parser";
 import {
 	FileID,
 	fileIDToHumanFriendly,
 	isLoadableFileID,
 	LoadableFileID,
-	defaultParseOptions,
-	ParseOptions,
-} from "../../lang/parser";
+} from "../../lang/parser/file_id";
 import * as tgui from "./../tgui";
 import { buttons } from "./commands";
 import * as ide from "./index";

--- a/src/ide/elements/editor-controller.ts
+++ b/src/ide/elements/editor-controller.ts
@@ -1,5 +1,7 @@
 import {
 	FileID,
+	fileIDHasNamespace,
+	fileIDToContextDependentFilename,
 	fileIDToHumanFriendly,
 	splitFileIDAtColon,
 } from "../../lang/parser/file_id";
@@ -55,7 +57,6 @@ export class EditorController {
 		this.#onActivate = onActivate;
 		this.close = onClosed;
 		this.#onBeforeFilenameChange = onBeforeFilenameChange;
-		const humanFriendlyName = fileIDToHumanFriendly(filename);
 
 		// create tab
 		this.tab = tgui.createElement({
@@ -66,7 +67,7 @@ export class EditorController {
 			(this.tabLabel = tgui.createElement({
 				type: "span",
 				classname: "name",
-				text: humanFriendlyName,
+				text: "",
 				click: () => onActivate(),
 			})),
 			tgui.createElement({
@@ -85,8 +86,9 @@ export class EditorController {
 		this.runOption = tgui.createElement({
 			type: "option",
 			properties: { value: filename },
-			text: humanFriendlyName,
+			text: "",
 		});
+		this.updateUITextsForFileID();
 
 		// create editor view
 		const ed = (this.editorView = new Editor({
@@ -186,12 +188,17 @@ export class EditorController {
 	saveAs(filename: FileID) {
 		this.#onBeforeFilenameChange(filename);
 
-		this.tabLabel.innerText = filename;
-		this.runOption.innerText = filename;
-		this.runOption.value = filename;
-
 		this.#filename = filename;
+		this.updateUITextsForFileID();
+		this.runOption.value = filename;
 		this.save();
+	}
+
+	private updateUITextsForFileID() {
+		this.tabLabel.innerText = fileIDToContextDependentFilename(
+			this.#filename
+		);
+		this.runOption.innerText = fileIDToHumanFriendly(this.#filename);
 	}
 
 	save() {

--- a/src/ide/elements/editor-controller.ts
+++ b/src/ide/elements/editor-controller.ts
@@ -2,7 +2,7 @@ import {
 	FileID,
 	fileIDToHumanFriendly,
 	splitFileIDAtColon,
-} from "../../lang/parser";
+} from "../../lang/parser/file_id";
 import { Editor } from "../editor";
 import * as tgui from "../tgui";
 import { confirmFileDiscard } from "./dialogs";

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -414,7 +414,11 @@ function updateProgramState(options?: { interpreterChanged: boolean }) {
 		if (stack && stack.length > 0) {
 			const frame = stack[stack.length - 1];
 			const pe = frame.pe[frame.pe.length - 1];
-			if (pe.where) {
+			if (
+				pe.where &&
+				pe.where.filename !== null &&
+				isLoadableFileID(pe.where.filename)
+			) {
 				collection.openEditorFromFile(pe.where.filename, {
 					line: pe.where.line - 1,
 					character: pe.where.ch,

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -6,7 +6,13 @@ import { icons } from "../icons";
 import * as tgui from "../tgui";
 import { tutorial } from "../tutorial";
 import { EditorCollection } from "./collection";
-import { buttons, cmd_download, cmd_export, cmd_upload } from "./commands";
+import {
+	buttons,
+	cmd_download,
+	cmd_export,
+	cmd_upload,
+	existsActiveSession,
+} from "./commands";
 import {
 	createCanvas,
 	createIDEInterpreter,
@@ -175,6 +181,10 @@ export async function prepareRun(): Promise<InterpreterSession | null> {
 	const { program, errors } = await parseProgram(parseInput, parseOptions);
 
 	// everything after that should ideally be synchronous
+	if (existsActiveSession()) {
+		return null;
+	}
+
 	clear();
 	for (const err of errors) {
 		addMessage(

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -142,29 +142,48 @@ export function clear() {
 	updateProgramState({ interpreterChanged: true });
 }
 
+/** @see createParseInput */
+export type ParseInputIncludeSpecification = {
+	parseInput: ParseInput;
+	includeResolutions: [string, string, string][] | null;
+	includeSourceResolutions: Map<string, string>;
+};
+
 /**
  * Create ParseInput from the current editors
  *
- * @returns a ParseInput object or `null` if no editors are open
+ * @returns
+ *	- `parseInput`: a ParseInput object
+ *	- `includeResolutions`: array of triples `[includingFile, includeOperand,
+ *		resolvedFilename]`, meaning that that in `includingFile`, an include with
+ *		operand `includeOperand` resolves to the file `resolvedFilename`. null
+ *		if resolutions weren't used (i.e. the includeOperand is always the same
+ *		as the resolvedFilename)
+ *	- `includeSourceResolutions`: Map from resolved filenames (third entry in
+ *		includeResolutions triples) to their sources
+ *	or null if the current run selection could not be resolved.
+ *	`includeResolutions` and `includeSourceResolutions` will only be filled once
+ *	`parseInput` is actually parsed.
  */
-export function createParseInput(
-	files = new Map<string, ParseInput>()
-): ParseInput | null {
-	function getFile(filename: string): ParseInput | null {
-		const existing = files.get(filename);
-		if (existing) return existing;
+export async function createParseInput(): Promise<ParseInputIncludeSpecification | null> {
+	const includeSourceResolutions: Map<string, string> = new Map();
 
+	const resolveInclude = (filename: string): ParseInput | null => {
 		const source =
 			collection.getEditor(filename)?.editorView.text() ??
 			localStorage.getItem(`tscript.code.${filename}`);
-		if (!source) return null;
+		if (source === null) return null;
+		includeSourceResolutions.set(filename, source);
+		return { source, filename, resolveInclude };
+	};
 
-		const file: ParseInput = { filename, source, resolveInclude: getFile };
-		files.set(filename, file);
-		return file;
-	}
-
-	return getFile(getRunSelection());
+	const mainParseInput = resolveInclude(getRunSelection());
+	if (mainParseInput === null) return null;
+	return {
+		parseInput: mainParseInput,
+		includeSourceResolutions,
+		includeResolutions: null,
+	};
 }
 
 /**
@@ -173,12 +192,16 @@ export function createParseInput(
  * @returns an {@link InterpreterSession} instance, or `null` on error
  */
 export async function prepareRun(): Promise<InterpreterSession | null> {
-	const parseInput = createParseInput();
+	const parseInput = (await createParseInput())?.parseInput;
 	if (!parseInput) {
 		return null;
 	}
 
-	const { program, errors } = await parseProgram(parseInput, parseOptions);
+	const { program, errors } = await parseProgram(
+		parseInput,
+		true,
+		parseOptions
+	);
 
 	// everything after that should ideally be synchronous
 	if (existsActiveSession()) {

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -164,14 +164,18 @@ export function createParseInput(
 /**
  * Prepare everything for the program to start running,
  * put the IDE into stepping mode at the start of the program.
+ * @returns an {@link InterpreterSession} instance, or `null` on error
  */
-export function prepareRun(): InterpreterSession | null {
-	clear();
-
+export async function prepareRun(): Promise<InterpreterSession | null> {
 	const parseInput = createParseInput();
-	if (!parseInput) return null;
+	if (!parseInput) {
+		return null;
+	}
 
-	const { program, errors } = parseProgram(parseInput, parseOptions);
+	const { program, errors } = await parseProgram(parseInput, parseOptions);
+
+	// everything after that should ideally be synchronous
+	clear();
 	for (const err of errors) {
 		addMessage(
 			err.type,
@@ -187,7 +191,9 @@ export function prepareRun(): InterpreterSession | null {
 			err.type === "error" ? err.href : undefined
 		);
 	}
-	if (!program) return null;
+	if (!program) {
+		return null;
+	}
 
 	interpreterSession = new InterpreterSession(
 		program,

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -1,9 +1,8 @@
 import { ErrorHelper } from "../../lang/errors/ErrorHelper";
 import { Interpreter } from "../../lang/interpreter/interpreter";
 import { ProgramRoot } from "../../lang/interpreter/program-elements";
+import { ParseInput, parseProgram } from "../../lang/parser";
 import {
-	ParseInput,
-	parseProgram,
 	FileID,
 	LocalStorageFileID,
 	StringFileID,
@@ -13,7 +12,7 @@ import {
 	isLoadableFileID,
 	localstorageFileID,
 	stringFileID,
-} from "../../lang/parser";
+} from "../../lang/parser/file_id";
 import { toClipboard } from "../clipboard";
 import { icons } from "../icons";
 import * as tgui from "../tgui";

--- a/src/ide/elements/utils.ts
+++ b/src/ide/elements/utils.ts
@@ -1,6 +1,6 @@
 import * as ide from ".";
 import { Interpreter } from "../../lang/interpreter/interpreter";
-import { localstorageFileID } from "../../lang/parser";
+import { localstorageFileID } from "../../lang/parser/file_id";
 import { fileDlg } from "./dialogs";
 
 export const type2css = [

--- a/src/ide/elements/utils.ts
+++ b/src/ide/elements/utils.ts
@@ -1,5 +1,6 @@
 import * as ide from ".";
 import { Interpreter } from "../../lang/interpreter/interpreter";
+import { localstorageFileID } from "../../lang/parser";
 import { fileDlg } from "./dialogs";
 
 export const type2css = [
@@ -40,14 +41,15 @@ export function importData(text: string, filename?: string) {
 	if (filename) {
 		const isSavedDoc =
 			localStorage.getItem("tscript.code." + filename) !== null;
-		if (!isSavedDoc && !ide.collection.getEditor(filename)) {
-			ide.collection.openEditorFromData(filename, text);
+		const fileID = localstorageFileID(filename);
+		if (!isSavedDoc && !ide.collection.getEditor(fileID)) {
+			ide.collection.openEditorFromData(fileID, text);
 			return;
 		}
 	}
 
 	fileDlg("Save file as ...", filename ?? "", true, "Save", (filename) => {
 		// the user has chosen, replace existing files
-		ide.collection.openEditorFromData(filename, text);
+		ide.collection.openEditorFromData(localstorageFileID(filename), text);
 	});
 }

--- a/src/ide/standalone.ts
+++ b/src/ide/standalone.ts
@@ -1,13 +1,12 @@
+import { ParseInput, parseProgram } from "../lang/parser";
 import {
-	ParseInput,
-	parseProgram,
 	FileID,
 	StringFileID,
 	fileIDToContextDependentFilename,
 	splitFileIDAtColon,
 	fileIDToHumanFriendly,
 	stringFileID,
-} from "../lang/parser";
+} from "../lang/parser/file_id";
 import { IncludeResolutionList } from "./elements";
 import {
 	createCanvas,

--- a/src/ide/standalone.ts
+++ b/src/ide/standalone.ts
@@ -5,8 +5,17 @@ import {
 	createTurtle,
 } from "./elements/create-interpreter";
 
+export type StandaloneCode = {
+	includeSourceResolutions: Record<string, string>;
+	/**
+	 * triples [includingFile, includeOperand, stdFilename], where stdFilename
+	 * is in the key set of includeSourceResolutions.
+	 */
+	includeResolutions: [string, string, string][] | null;
+	main: string;
+};
 export type StandaloneData = {
-	code: { documents: Record<string, string>; main: string };
+	code: StandaloneCode;
 	mode: "canvas" | "turtle";
 };
 
@@ -14,19 +23,38 @@ export function showStandalonePage(
 	container: HTMLElement,
 	data: StandaloneData
 ): void {
-	const { documents } = data.code;
+	const { includeSourceResolutions, includeResolutions } = data.code;
+	function resolveIncludeToStdFilename(
+		includingFile: string,
+		includeOperand: string
+	): string | null {
+		if (includeResolutions === null) {
+			return includeOperand;
+		} else {
+			const relevantTriple = includeResolutions.find(
+				(val) => val[0] === includingFile && val[1] === includeOperand
+			);
+			if (relevantTriple === undefined) {
+				console.error(
+					`Unexpectedly could not resolve include in "${includingFile}" operand "${includeOperand}" to standardized filename`
+				);
+				return null;
+			}
+			return relevantTriple[2];
+		}
+	}
 	function getParseInput(filename: string): ParseInput<false> | null {
-		if (!Object.hasOwn(documents, filename)) return null;
 		return {
 			filename,
-			source: documents[filename],
+			source: includeSourceResolutions[filename],
+			resolveIncludeToStdFilename: resolveIncludeToStdFilename,
 			resolveInclude: getParseInput,
 		};
 	}
 	const mainFile = getParseInput(data.code.main);
 	if (!mainFile) return; // This has been validated on export
 
-	const { program } = parseProgram(mainFile);
+	const { program } = parseProgram(mainFile, false);
 	if (program == null) return; // This has been validated on export
 
 	const interpreter = createIDEInterpreter(program);

--- a/src/ide/standalone.ts
+++ b/src/ide/standalone.ts
@@ -15,7 +15,7 @@ export function showStandalonePage(
 	data: StandaloneData
 ): void {
 	const { documents } = data.code;
-	function getParseInput(filename: string): ParseInput | null {
+	function getParseInput(filename: string): ParseInput<false> | null {
 		if (!Object.hasOwn(documents, filename)) return null;
 		return {
 			filename,

--- a/src/lang/errors/ErrorHelper.ts
+++ b/src/lang/errors/ErrorHelper.ts
@@ -1,3 +1,4 @@
+import { FileID, fileIDToContextDependentFilename } from "../parser";
 import { AssertionError } from "./AssertionError";
 import { RuntimeError } from "./RuntimeError";
 
@@ -28,6 +29,22 @@ export class ErrorHelper {
 		let ret = tokens[0];
 		for (let i = 0; i < args.length; i++) ret += args[i] + tokens[i + 1];
 		return ret;
+	}
+
+	public static getLocatedErrorMsg(
+		errorType: string,
+		fileID: FileID | undefined,
+		line: number | undefined,
+		msg: string
+	): string {
+		const humanReadable =
+			fileID !== undefined && fileIDToContextDependentFilename(fileID);
+		return (
+			errorType +
+			(humanReadable ? ` in file '${humanReadable}'` : "") +
+			(line ? ` in line ${line}` : "") +
+			`: ${msg}`
+		);
 	}
 
 	public static getError(

--- a/src/lang/errors/ErrorHelper.ts
+++ b/src/lang/errors/ErrorHelper.ts
@@ -1,4 +1,4 @@
-import { FileID, fileIDToContextDependentFilename } from "../parser";
+import { FileID, fileIDToContextDependentFilename } from "../parser/file_id";
 import { AssertionError } from "./AssertionError";
 import { RuntimeError } from "./RuntimeError";
 

--- a/src/lang/errors/ErrorHelper.ts
+++ b/src/lang/errors/ErrorHelper.ts
@@ -51,7 +51,7 @@ export class ErrorHelper {
 		path,
 		args: Array<any> | undefined = undefined,
 		stack: any = undefined,
-		_filename: string | undefined = undefined,
+		_filename: FileID | undefined = undefined,
 		_line: number | undefined = undefined,
 		_ch: number | undefined = undefined
 	) {
@@ -63,7 +63,7 @@ export class ErrorHelper {
 
 		let message = ErrorHelper.composeError(path, args);
 		let href = "#/errors" + path;
-		let filename: any = null,
+		let filename: FileID | null = null,
 			line: any = null,
 			ch: any = null;
 
@@ -90,7 +90,7 @@ export class ErrorHelper {
 			}
 			if (line !== null) break;
 		}
-		return new RuntimeError(message, filename, line, ch, href);
+		return new RuntimeError(message, filename ?? undefined, line, ch, href);
 	}
 	// raise a fatal runtime error, preserve the interpreter state for debugging
 	public static error(

--- a/src/lang/errors/RuntimeError.ts
+++ b/src/lang/errors/RuntimeError.ts
@@ -1,28 +1,26 @@
+import { FileID } from "../parser";
+
 // exception type
 export class RuntimeError extends Error {
-	public filename;
-	public line;
-	public ch;
-	public href;
+	public filename: FileID | null;
+	public line: number | null;
+	public ch: number | null;
+	public href: string;
 
 	public constructor(
-		msg,
-		filename: any = undefined,
-		line: any = undefined,
-		ch: any = undefined,
-		href: any = undefined
+		msg: string,
+		filename?: FileID,
+		line?: number,
+		ch?: number,
+		href?: string
 	) {
 		super();
 		this.message = msg;
 		this.name = "Runtime Error";
 
-		if (typeof filename === "undefined") filename = null;
-		if (typeof line === "undefined") line = null;
-		if (typeof ch === "undefined") ch = null;
-		if (typeof href === "undefined") href = "";
-		this.filename = filename;
-		this.line = line;
-		this.ch = ch;
-		this.href = href;
+		this.filename = filename ?? null;
+		this.line = line ?? null;
+		this.ch = ch ?? null;
+		this.href = href ?? "";
 	}
 }

--- a/src/lang/errors/RuntimeError.ts
+++ b/src/lang/errors/RuntimeError.ts
@@ -1,4 +1,4 @@
-import { FileID } from "../parser";
+import { FileID } from "../parser/file_id";
 
 // exception type
 export class RuntimeError extends Error {

--- a/src/lang/interpreter/interpreter.ts
+++ b/src/lang/interpreter/interpreter.ts
@@ -3,7 +3,7 @@ import { RuntimeError } from "../errors/RuntimeError";
 import { TScript } from "..";
 import { Typeid } from "../helpers/typeIds";
 import { ProgramElementBase, ProgramRoot } from "./program-elements";
-import { FileID } from "../parser";
+import { FileID } from "../parser/file_id";
 
 export interface InterpreterOptions {
 	/** @default 10000 */

--- a/src/lang/interpreter/interpreter.ts
+++ b/src/lang/interpreter/interpreter.ts
@@ -3,6 +3,7 @@ import { RuntimeError } from "../errors/RuntimeError";
 import { TScript } from "..";
 import { Typeid } from "../helpers/typeIds";
 import { ProgramRoot } from "./program-elements";
+import { FileID } from "../parser";
 
 export interface InterpreterOptions {
 	/** @default 10000 */
@@ -311,12 +312,12 @@ export class Interpreter {
 					const ch = pe?.where?.ch || ex.ch;
 
 					this.service.message(
-						"runtime error " +
-							(filename ? "in file '" + filename + "' " : "") +
-							"in line " +
-							line +
-							": " +
-							ex.message,
+						ErrorHelper.getLocatedErrorMsg(
+							"runtime error",
+							filename,
+							line,
+							ex.message
+						),
 						filename,
 						line,
 						ch,
@@ -441,10 +442,10 @@ export class Interpreter {
 	 *
 	 * @param lines one-based positions of breakpoints
 	 */
-	public defineBreakpoints(lines: Iterable<number>, filename: string) {
+	public defineBreakpoints(lines: Iterable<number>, fileID: FileID) {
 		let pos = new Set<number>();
 		let changed = false;
-		const breakpoints = this.program.breakpoints[filename];
+		const breakpoints = this.program.breakpoints[fileID];
 		if (!breakpoints) return null;
 
 		// loop over all positions
@@ -486,7 +487,7 @@ export class Interpreter {
 	 */
 	public toggleBreakpoint(
 		line: number,
-		filename: string
+		filename: FileID
 	): { line: number; active: boolean } | null {
 		const breakpoints = this.program.breakpoints[filename];
 		if (!breakpoints) return null;

--- a/src/lang/interpreter/interpreter.ts
+++ b/src/lang/interpreter/interpreter.ts
@@ -2,7 +2,7 @@ import { ErrorHelper } from "../errors/ErrorHelper";
 import { RuntimeError } from "../errors/RuntimeError";
 import { TScript } from "..";
 import { Typeid } from "../helpers/typeIds";
-import { ProgramRoot } from "./program-elements";
+import { ProgramElementBase, ProgramRoot } from "./program-elements";
 import { FileID } from "../parser";
 
 export interface InterpreterOptions {
@@ -25,7 +25,7 @@ export type InterpreterStatus =
  * For calls to non-static methods, the frame contains a field for the object in addition.
  */
 export interface StackFrame {
-	pe: any[];
+	pe: (ProgramElementBase<string> & Record<string, any>)[];
 	ip: number[];
 	temporaries: any[];
 	variables: any[];

--- a/src/lang/interpreter/program-elements.ts
+++ b/src/lang/interpreter/program-elements.ts
@@ -1,4 +1,4 @@
-import { ParserPosition } from "../parser";
+import { ParserPosition, FileID } from "../parser";
 import { Interpreter } from "./interpreter";
 
 interface ProgramElementBase<Type extends string> {
@@ -45,7 +45,7 @@ export interface ProgramRoot extends ProgramElementBase<"global scope"> {
 	/** mapping of index to name */
 	variables: string[];
 	/** mapping of line numbers to breakpoints (some lines do not have breakpoints) */
-	breakpoints: Record<string, Record<number, Breakpoint>>;
+	breakpoints: Record<FileID, Record<number, Breakpoint>>;
 	/** total number of lines in the program = maximal line number */
 	lines: number;
 }

--- a/src/lang/interpreter/program-elements.ts
+++ b/src/lang/interpreter/program-elements.ts
@@ -1,4 +1,5 @@
-import { ParserPosition, FileID } from "../parser";
+import { ParserPosition } from "../parser";
+import { FileID } from "../parser/file_id";
 import { Interpreter } from "./interpreter";
 
 export interface ProgramElementBase<Type extends string> {

--- a/src/lang/interpreter/program-elements.ts
+++ b/src/lang/interpreter/program-elements.ts
@@ -1,7 +1,7 @@
 import { ParserPosition, FileID } from "../parser";
 import { Interpreter } from "./interpreter";
 
-interface ProgramElementBase<Type extends string> {
+export interface ProgramElementBase<Type extends string> {
 	readonly petype: Type;
 
 	/** The position where this program element starts in the source code */

--- a/src/lang/parser/file_id.ts
+++ b/src/lang/parser/file_id.ts
@@ -1,0 +1,84 @@
+/**
+ * Namespaces used as the prefix in FileID. "string" is used for inputs that
+ * aren't attached to a file, as in parseProgramFromString.
+ *
+ * localstorage: The corresponding FileID suffix is just the name of the "file"
+ * string: The corresponding FileID suffix should be the context dependent
+ *		filename as returned by fileIDToContextDependentFilename.
+ */
+export const fileIDNamespaces = ["localstorage", "string"] as const;
+export type FileIDNamespace = (typeof fileIDNamespaces)[number];
+export const loadableFileIDNamespaces = ["localstorage"] as const;
+export type LoadableFileIDNamespace = (typeof loadableFileIDNamespaces)[number];
+
+export type StringFileID = `string:${string}`;
+export type LocalStorageFileID = `localstorage:${string}`;
+export type FileID = StringFileID | LocalStorageFileID;
+/** Subset of files that are actually stored somewhere */
+export type LoadableFileID = LocalStorageFileID;
+
+export function isLoadableFileID(fileID: FileID): fileID is LoadableFileID {
+	return loadableFileIDNamespaces.some((ns) =>
+		fileIDHasNamespace(fileID, ns)
+	);
+}
+
+export function localstorageFileID(filename: string): LocalStorageFileID {
+	return `localstorage:${filename}`;
+}
+
+export function stringFileID(filename: string): StringFileID {
+	return `string:${filename}`;
+}
+
+/**
+ * Given a file id, returns a string that unambiguously represents that file to
+ * the user, but leaving out the namespace (and in future uses, other contexts
+ * that the user should be aware of).
+ */
+export function fileIDToContextDependentFilename(fileID: FileID): string {
+	const [ns, suffix] = splitFileIDAtColon(fileID);
+	switch (ns) {
+		case "localstorage":
+			return suffix;
+		case "string":
+			return suffix;
+	}
+}
+
+export function fileIDToHumanFriendly(fileID: FileID): string {
+	const [ns, suffix] = splitFileIDAtColon(fileID);
+	switch (ns) {
+		case "localstorage":
+			return suffix;
+		case "string":
+			return `${suffix} (no file)`;
+	}
+}
+
+export function fileIDHasNamespace<NamespaceT extends FileIDNamespace>(
+	fileID: FileID,
+	namespace: NamespaceT
+): fileID is `${NamespaceT}:${string}` {
+	return fileID.startsWith(namespace);
+}
+
+export function splitFileIDAtColon(fileID: FileID): [FileIDNamespace, string] {
+	const ns = fileID.split(":", 1)[0] as FileIDNamespace;
+	const suffix = fileID.slice(ns.length + 1);
+	return [ns, suffix];
+}
+
+export function localStorageFileIDToFilename(
+	fileID: LocalStorageFileID
+): string {
+	return splitFileIDAtColon(fileID)[1];
+}
+
+export function fileIDChangeNamespace<FileIDNamespaceT extends FileIDNamespace>(
+	fileID: FileID,
+	namespace: FileIDNamespaceT
+): `${FileIDNamespaceT}:${string}` {
+	const [_, suffix] = splitFileIDAtColon(fileID);
+	return `${namespace}:${suffix}`;
+}

--- a/src/lang/parser/index.ts
+++ b/src/lang/parser/index.ts
@@ -10,6 +10,7 @@ import { scopestep } from "../helpers/steps";
 import { simfalse } from "../helpers/sims";
 import { parse_statement_or_declaration } from "./parse_statementordeclaration";
 import { parse_include } from "./parse_include";
+import { FileID, stringFileID } from "./file_id";
 
 export interface ParserPosition {
 	/** filename or null */
@@ -139,91 +140,6 @@ export interface ParseOptions {
 export const defaultParseOptions: ParseOptions = {
 	checkstyle: false,
 };
-
-/**
- * Namespaces used as the prefix in FileID. "string" is used for inputs that
- * aren't attached to a file, as in parseProgramFromString.
- *
- * localstorage: The corresponding FileID suffix is just the name of the "file"
- * string: The corresponding FileID suffix should be the context dependent
- *		filename as returned by fileIDToContextDependentFilename.
- */
-export const fileIDNamespaces = ["localstorage", "string"] as const;
-export type FileIDNamespace = (typeof fileIDNamespaces)[number];
-export const loadableFileIDNamespaces = ["localstorage"] as const;
-export type LoadableFileIDNamespace = (typeof loadableFileIDNamespaces)[number];
-
-export type StringFileID = `string:${string}`;
-export type LocalStorageFileID = `localstorage:${string}`;
-export type FileID = StringFileID | LocalStorageFileID;
-/** Subset of files that are actually stored somewhere */
-export type LoadableFileID = LocalStorageFileID;
-
-export function isLoadableFileID(fileID: FileID): fileID is LoadableFileID {
-	return loadableFileIDNamespaces.some((ns) =>
-		fileIDHasNamespace(fileID, ns)
-	);
-}
-
-export function localstorageFileID(filename: string): LocalStorageFileID {
-	return `localstorage:${filename}`;
-}
-
-export function stringFileID(filename: string): StringFileID {
-	return `string:${filename}`;
-}
-
-/**
- * Given a file id, returns a string that unambiguously represents that file to
- * the user, but leaving out the namespace (and in future uses, other contexts
- * that the user should be aware of).
- */
-export function fileIDToContextDependentFilename(fileID: FileID): string {
-	const [ns, suffix] = splitFileIDAtColon(fileID);
-	switch (ns) {
-		case "localstorage":
-			return suffix;
-		case "string":
-			return suffix;
-	}
-}
-
-export function fileIDToHumanFriendly(fileID: FileID): string {
-	const [ns, suffix] = splitFileIDAtColon(fileID);
-	switch (ns) {
-		case "localstorage":
-			return suffix;
-		case "string":
-			return `${suffix} (no file)`;
-	}
-}
-
-export function fileIDHasNamespace<NamespaceT extends FileIDNamespace>(
-	fileID: FileID,
-	namespace: NamespaceT
-): fileID is `${NamespaceT}:${string}` {
-	return fileID.startsWith(namespace);
-}
-
-export function splitFileIDAtColon(fileID: FileID): [FileIDNamespace, string] {
-	const ns = fileID.split(":", 1)[0] as FileIDNamespace;
-	const suffix = fileID.slice(ns.length + 1);
-	return [ns, suffix];
-}
-
-export function localStorageFileIDToFilename(
-	fileID: LocalStorageFileID
-): string {
-	return splitFileIDAtColon(fileID)[1];
-}
-
-export function fileIDChangeNamespace<FileIDNamespaceT extends FileIDNamespace>(
-	fileID: FileID,
-	namespace: FileIDNamespaceT
-): `${FileIDNamespaceT}:${string}` {
-	const [_, suffix] = splitFileIDAtColon(fileID);
-	return `${namespace}:${suffix}`;
-}
 
 /**
  * If `AllowWait` is `false`, evaluates to `T`; if `AllowWait` is `true`,

--- a/src/lang/parser/index.ts
+++ b/src/lang/parser/index.ts
@@ -140,7 +140,10 @@ export const defaultParseOptions: ParseOptions = {
 	checkstyle: false,
 };
 
-export interface ParseInput {
+/**
+ * @param AllowAwait If true, resolveInclude may also return Promise
+ */
+export interface ParseInput<AllowAwait extends boolean = true> {
 	filename: string;
 	source: string;
 
@@ -150,7 +153,14 @@ export interface ParseInput {
 	 * @param filename the filename as specified in the include statement
 	 * @returns the file to be included or null if none could be found
 	 */
-	resolveInclude(filename: string): ParseInput | null;
+	resolveInclude(
+		filename: string
+	):
+		| ParseInput<AllowAwait>
+		| null
+		| (AllowAwait extends true
+				? Promise<ParseInput<AllowAwait> | null>
+				: never);
 }
 
 export interface ParseResult {
@@ -159,21 +169,37 @@ export interface ParseResult {
 	errors: ParseErrorOrWarning[];
 }
 
-export function parseProgramFromString(source: string, options?: ParseOptions) {
+export function parseProgramFromString(
+	source: string,
+	options?: ParseOptions
+): ParseResult {
 	return parseProgram(
 		{
 			filename: "main",
 			source,
 			resolveInclude: () => null,
 		},
-		options
+		options,
+		false
 	);
 }
 
+/**
+ * @param allowAwait corresponds to AllowAwait type parameter. If true,
+ * mainInput.resolveInclude may return a promise and parseProgram also returns a
+ * promise. true by default.
+ * @param options `defaultParseOptions` by default
+ */
+export function parseProgram<AllowAwait extends boolean = true>(
+	mainInput: ParseInput<AllowAwait>,
+	options?: ParseOptions,
+	allowAwait?: AllowAwait
+): AllowAwait extends true ? Promise<ParseResult> : ParseResult;
 export function parseProgram(
-	mainInput: ParseInput,
-	options: ParseOptions = defaultParseOptions
-): ParseResult {
+	mainInput: ParseInput<any>,
+	options: ParseOptions = defaultParseOptions,
+	allowAwait: boolean = true
+): Promise<ParseResult> | ParseResult {
 	const includedFiles = new Set<string>();
 	/** list of errors */
 	const errors: ParseErrorOrWarning[] = [];
@@ -206,15 +232,53 @@ export function parseProgram(
 	}
 
 	/**
-	 * Parse one library or program from a file. Includes are supported
+	 * Parse one library or program from a file. Includes are supported.
+	 *
+	 * To support runtime switching between async and sync, parseFile and
+	 * parseFileAsync both use parseFileGenerator under the hood
+	 * and only act as event loops for the returned Generator. In parseFile, all
+	 * yields are evaluated to its operand, which allows the function to remain
+	 * synchronous. In parseFileAsync, yields are evaluated to the awaited value
+	 * of the operand, thus making yields in parseFileGenerator equivalent to
+	 * awaits.
 	 */
-	function parseFile(file: ParseInput) {
+	function parseFile(file: ParseInput<any>) {
+		const gen = parseFileGenerator(file);
+		// let yield expressions always evaluate to its operand
+		for (let e = gen.next(); !e.done; e = gen.next(e.value)) {
+			if (e.value instanceof Promise) {
+				throw new Error("Unexpected Promise, async not allowed");
+			}
+		}
+	}
+	async function parseFileAsync(file: ParseInput<any>): Promise<void> {
+		const gen = parseFileGenerator(file);
+		let e = gen.next();
+		while (!e.done) {
+			// pass control to event loop and get result
+			const awaitedVal = await e.value;
+			// continue generator and provide result
+			e = gen.next(awaitedVal);
+		}
+	}
+	/**
+	 * Depending on where this is called, yield corresponds to either just
+	 * return the value (expecting it to not be a promise), or awaiting it if it
+	 * is a promise.
+	 */
+	function* parseFileGenerator(
+		file: ParseInput<any>
+	): Generator<
+		ReturnType<ParseInput<any>["resolveInclude"]>,
+		void,
+		ParseInput<any> | null
+	> {
 		includedFiles.add(file.filename);
 		state.setSource(file.source, null, file.filename);
 		while (state.good()) {
 			const inc = parse_include(state, program, options);
 			if (inc !== null) {
-				const targetFile = file.resolveInclude(inc.filename);
+				const targetFile = yield file.resolveInclude(inc.filename);
 				if (!targetFile) {
 					// the file was not found
 					state.set(inc.position);
@@ -234,7 +298,7 @@ export function parseProgram(
 					};
 
 					// import the file
-					parseFile(targetFile);
+					yield* parseFileGenerator(targetFile);
 
 					// restore the state
 					state.source = backup.source;
@@ -263,10 +327,33 @@ export function parseProgram(
 		parseString(lib_turtle.source, lib_turtle.impl);
 		parseString(lib_canvas.source, lib_canvas.impl);
 		parseString(lib_audio.source, lib_audio.impl);
-
-		// parse the user's source code
 		program.where = state.get();
-		parseFile(mainInput);
+	} catch (e) {
+		handleError(e);
+		return constructResult();
+	}
+
+	if (allowAwait) {
+		return (async () => {
+			try {
+				await parseFileAsync(mainInput);
+				afterParse();
+			} catch (e) {
+				handleError(e);
+			}
+			return constructResult();
+		})();
+	} else {
+		try {
+			parseFile(mainInput);
+			afterParse();
+		} catch (e) {
+			handleError(e);
+		}
+		return constructResult();
+	}
+
+	function afterParse() {
 		program.lines = state.line;
 
 		// append an "end" breakpoint
@@ -285,7 +372,15 @@ export function parseProgram(
 
 		// further passes may follow in the future, e.g., for optimizations
 		// compilerPass("Optimize");
-	} catch (ex: any) {
+	}
+
+	function constructResult() {
+		return errors.length > 0
+			? { program: null, errors }
+			: { program, errors: [] };
+	}
+
+	function handleError(ex: any) {
 		// ignore the actual exception and rely on state.errors instead
 		if (ex.name !== "Parse Error") {
 			// report an internal parser error
@@ -298,10 +393,6 @@ export function parseProgram(
 			});
 		}
 	}
-
-	return errors.length > 0
-		? { program: null, errors }
-		: { program, errors: [] };
 }
 
 /** recursive compiler pass through the syntax tree */


### PR DESCRIPTION
(Contains pull request "Support asynchronously resolving include statement to included source code")

Implements file IDs as a replacement for most internal uses of "filenames" in preparation for projects as an alternative file storage (without affecting the user interface). For example, the file ID for a file "MyFile" (stored in localStorage) is "localstorage:MyFile". A file ID is made up of a namespace (the part before the colon) and some suffix (starting after the colon) that identifies the file uniquely among all files belonging to that namespace.

Currently, the only namespaces are "localstorage" and "string". The namespace "localstorage" is used for files that are stored in localStorage (or exist as an editor tab). "string" is used whenever a program needs to be parsed from strings that don't correspond to files in localStorage (i.e., for parseProgramFromString and for standalone pages). Downstream, we additionally have the "project" namespace for files stored in a project.