### PR TITLE
(v3) Support asynchronously resolving include statement to included source code

### DIFF
--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -95,11 +95,6 @@ function cmd_reset() {
 	ide.clear();
 }
 
-export function existsActiveSession(): boolean {
-	let session = ide.interpreterSession;
-	return session !== null && !interpreterEnded(session.interpreter);
-}
-
 /**
  * Gets the active interpreter session or creates a new one if no program is running
  */

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -95,6 +95,11 @@ function cmd_reset() {
 	ide.clear();
 }
 
+export function existsActiveSession(): boolean {
+	let session = ide.interpreterSession;
+	return session !== null && !interpreterEnded(session.interpreter);
+}
+
 /**
  * Gets the active interpreter session or creates a new one if no program is running
  */
@@ -131,7 +136,7 @@ async function cmd_step_out() {
 
 export async function cmd_export() {
 	const parsedFiles = new Map<string, ParseInput>();
-	const parseInput = ide.createParseInput(parsedFiles);
+	const parseInput = await ide.createParseInput(parsedFiles);
 	if (!parseInput) return;
 
 	// check that the code at least compiles

--- a/src/ide/elements/commands.ts
+++ b/src/ide/elements/commands.ts
@@ -98,18 +98,18 @@ function cmd_reset() {
 /**
  * Gets the active interpreter session or creates a new one if no program is running
  */
-function getOrRestartSession() {
+async function getOrRestartSession() {
 	let session = ide.interpreterSession;
-	if (!session || interpreterEnded(session.interpreter)) {
+	if (session && !interpreterEnded(session.interpreter)) {
+		return session;
+	} else {
 		// (re-)start the interpreter
-		session = ide.prepareRun();
+		return await ide.prepareRun();
 	}
-
-	return session;
 }
 
-function cmd_run() {
-	getOrRestartSession()?.interpreter.run();
+async function cmd_run() {
+	(await getOrRestartSession())?.interpreter.run();
 }
 
 function cmd_interrupt() {
@@ -117,25 +117,25 @@ function cmd_interrupt() {
 	if (interpreter && !interpreterEnded(interpreter)) interpreter.interrupt();
 }
 
-function cmd_step_into() {
-	getOrRestartSession()?.interpreter.step_into();
+async function cmd_step_into() {
+	(await getOrRestartSession())?.interpreter.step_into();
 }
 
-function cmd_step_over() {
-	getOrRestartSession()?.interpreter.step_over();
+async function cmd_step_over() {
+	(await getOrRestartSession())?.interpreter.step_over();
 }
 
-function cmd_step_out() {
-	getOrRestartSession()?.interpreter.step_out();
+async function cmd_step_out() {
+	(await getOrRestartSession())?.interpreter.step_out();
 }
 
-export function cmd_export() {
+export async function cmd_export() {
 	const parsedFiles = new Map<string, ParseInput>();
 	const parseInput = ide.createParseInput(parsedFiles);
 	if (!parseInput) return;
 
 	// check that the code at least compiles
-	let result = parseProgram(parseInput, parseOptions);
+	let result = await parseProgram(parseInput, parseOptions);
 	let program = result.program;
 	let errors = result.errors;
 	if (errors && errors.length > 0) {

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -6,7 +6,13 @@ import { icons } from "../icons";
 import * as tgui from "../tgui";
 import { tutorial } from "../tutorial";
 import { EditorCollection } from "./collection";
-import { buttons, cmd_download, cmd_export, cmd_upload } from "./commands";
+import {
+	buttons,
+	cmd_download,
+	cmd_export,
+	cmd_upload,
+	existsActiveSession,
+} from "./commands";
 import {
 	createCanvas,
 	createIDEInterpreter,
@@ -175,6 +181,10 @@ export async function prepareRun(): Promise<InterpreterSession | null> {
 	const { program, errors } = await parseProgram(parseInput, parseOptions);
 
 	// everything after that should ideally be synchronous
+	if (existsActiveSession()) {
+		return null;
+	}
+
 	clear();
 	for (const err of errors) {
 		addMessage(

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -6,13 +6,7 @@ import { icons } from "../icons";
 import * as tgui from "../tgui";
 import { tutorial } from "../tutorial";
 import { EditorCollection } from "./collection";
-import {
-	buttons,
-	cmd_download,
-	cmd_export,
-	cmd_upload,
-	existsActiveSession,
-} from "./commands";
+import { buttons, cmd_download, cmd_export, cmd_upload } from "./commands";
 import {
 	createCanvas,
 	createIDEInterpreter,
@@ -171,53 +165,64 @@ export async function createParseInput(
 	return getFile(getRunSelection());
 }
 
+let pendingInterpreterSession: Promise<InterpreterSession | null> | null = null;
+
 /**
  * Prepare everything for the program to start running,
  * put the IDE into stepping mode at the start of the program.
- * @returns an {@link InterpreterSession} instance, or `null` on error
+ * If this function is called while an earlier call to this function is still
+ * ongoing, it returns the promise from the first call. Destroys current
+ * interpreter.
+ * @returns an {@link InterpreterSession} instance, or `null` on error.
  */
 export async function prepareRun(): Promise<InterpreterSession | null> {
-	const parseInput = await createParseInput();
-	if (!parseInput) {
-		return null;
-	}
+	return (pendingInterpreterSession ??= createInterpreterSession().finally(
+		() => {
+			pendingInterpreterSession = null;
+		}
+	));
 
-	const { program, errors } = await parseProgram(parseInput, parseOptions);
+	async function createInterpreterSession() {
+		const parseInput = await createParseInput();
+		if (!parseInput) {
+			return null;
+		}
 
-	// everything after that should ideally be synchronous
-	if (existsActiveSession()) {
-		return null;
-	}
-
-	clear();
-	for (const err of errors) {
-		addMessage(
-			err.type,
-			err.type +
-				(err.filename ? " in file '" + err.filename + "'" : "") +
-				" in line " +
-				err.line +
-				": " +
-				err.message,
-			err.filename ?? undefined,
-			err.line,
-			err.ch,
-			err.type === "error" ? err.href : undefined
+		const { program, errors } = await parseProgram(
+			parseInput,
+			parseOptions
 		);
-	}
-	if (!program) {
-		return null;
-	}
 
-	interpreterSession = new InterpreterSession(
-		program,
-		turtleContainer,
-		canvasContainer
-	);
+		clear();
+		for (const err of errors) {
+			addMessage(
+				err.type,
+				err.type +
+					(err.filename ? " in file '" + err.filename + "'" : "") +
+					" in line " +
+					err.line +
+					": " +
+					err.message,
+				err.filename ?? undefined,
+				err.line,
+				err.ch,
+				err.type === "error" ? err.href : undefined
+			);
+		}
+		if (!program) {
+			return null;
+		}
 
-	// the IDE has an InterpreterSession now
-	updateProgramState({ interpreterChanged: true });
-	return interpreterSession;
+		interpreterSession = new InterpreterSession(
+			program,
+			turtleContainer,
+			canvasContainer
+		);
+
+		// the IDE has an InterpreterSession now
+		updateProgramState({ interpreterChanged: true });
+		return interpreterSession;
+	}
 }
 
 export class InterpreterSession {

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -164,14 +164,18 @@ export function createParseInput(
 /**
  * Prepare everything for the program to start running,
  * put the IDE into stepping mode at the start of the program.
+ * @returns an {@link InterpreterSession} instance, or `null` on error
  */
-export function prepareRun(): InterpreterSession | null {
-	clear();
-
+export async function prepareRun(): Promise<InterpreterSession | null> {
 	const parseInput = createParseInput();
-	if (!parseInput) return null;
+	if (!parseInput) {
+		return null;
+	}
 
-	const { program, errors } = parseProgram(parseInput, parseOptions);
+	const { program, errors } = await parseProgram(parseInput, parseOptions);
+
+	// everything after that should ideally be synchronous
+	clear();
 	for (const err of errors) {
 		addMessage(
 			err.type,
@@ -187,7 +191,9 @@ export function prepareRun(): InterpreterSession | null {
 			err.type === "error" ? err.href : undefined
 		);
 	}
-	if (!program) return null;
+	if (!program) {
+		return null;
+	}
 
 	interpreterSession = new InterpreterSession(
 		program,

--- a/src/ide/elements/index.ts
+++ b/src/ide/elements/index.ts
@@ -147,10 +147,10 @@ export function clear() {
  *
  * @returns a ParseInput object or `null` if no editors are open
  */
-export function createParseInput(
+export async function createParseInput(
 	files = new Map<string, ParseInput>()
-): ParseInput | null {
-	function getFile(filename: string): ParseInput | null {
+): Promise<ParseInput | null> {
+	async function getFile(filename: string): Promise<ParseInput | null> {
 		const existing = files.get(filename);
 		if (existing) return existing;
 
@@ -159,7 +159,11 @@ export function createParseInput(
 			localStorage.getItem(`tscript.code.${filename}`);
 		if (!source) return null;
 
-		const file: ParseInput = { filename, source, resolveInclude: getFile };
+		const file: ParseInput = {
+			filename,
+			source,
+			resolveInclude: getFile,
+		};
 		files.set(filename, file);
 		return file;
 	}
@@ -173,7 +177,7 @@ export function createParseInput(
  * @returns an {@link InterpreterSession} instance, or `null` on error
  */
 export async function prepareRun(): Promise<InterpreterSession | null> {
-	const parseInput = createParseInput();
+	const parseInput = await createParseInput();
 	if (!parseInput) {
 		return null;
 	}

--- a/src/ide/standalone.ts
+++ b/src/ide/standalone.ts
@@ -15,7 +15,7 @@ export function showStandalonePage(
 	data: StandaloneData
 ): void {
 	const { documents } = data.code;
-	function getParseInput(filename: string): ParseInput | null {
+	function getParseInput(filename: string): ParseInput<false> | null {
 		if (!Object.hasOwn(documents, filename)) return null;
 		return {
 			filename,

--- a/src/ide/standalone.ts
+++ b/src/ide/standalone.ts
@@ -10,12 +10,12 @@ export type StandaloneData = {
 	mode: "canvas" | "turtle";
 };
 
-export function showStandalonePage(
+export async function showStandalonePage(
 	container: HTMLElement,
 	data: StandaloneData
-): void {
+) {
 	const { documents } = data.code;
-	function getParseInput(filename: string): ParseInput<false> | null {
+	async function getParseInput(filename: string): Promise<ParseInput | null> {
 		if (!Object.hasOwn(documents, filename)) return null;
 		return {
 			filename,
@@ -23,10 +23,10 @@ export function showStandalonePage(
 			resolveInclude: getParseInput,
 		};
 	}
-	const mainFile = getParseInput(data.code.main);
+	const mainFile = await getParseInput(data.code.main);
 	if (!mainFile) return; // This has been validated on export
 
-	const { program } = parseProgram(mainFile);
+	const { program } = await parseProgram(mainFile);
 	if (program == null) return; // This has been validated on export
 
 	const interpreter = createIDEInterpreter(program);

--- a/src/lang/parser/index.ts
+++ b/src/lang/parser/index.ts
@@ -140,7 +140,10 @@ export const defaultParseOptions: ParseOptions = {
 	checkstyle: false,
 };
 
-export interface ParseInput {
+/**
+ * @param AllowAwait If true, resolveInclude may also return Promise
+ */
+export interface ParseInput<AllowAwait extends boolean = true> {
 	filename: string;
 	source: string;
 
@@ -150,7 +153,14 @@ export interface ParseInput {
 	 * @param filename the filename as specified in the include statement
 	 * @returns the file to be included or null if none could be found
 	 */
-	resolveInclude(filename: string): ParseInput | null;
+	resolveInclude(
+		filename: string
+	):
+		| ParseInput<AllowAwait>
+		| null
+		| (AllowAwait extends true
+				? Promise<ParseInput<AllowAwait> | null>
+				: never);
 }
 
 export interface ParseResult {
@@ -159,21 +169,37 @@ export interface ParseResult {
 	errors: ParseErrorOrWarning[];
 }
 
-export function parseProgramFromString(source: string, options?: ParseOptions) {
+export function parseProgramFromString(
+	source: string,
+	options?: ParseOptions
+): ParseResult {
 	return parseProgram(
 		{
 			filename: "main",
 			source,
 			resolveInclude: () => null,
 		},
-		options
+		options,
+		false
 	);
 }
 
+/**
+ * @param allowAwait corresponds to AllowAwait type parameter. If true,
+ * mainInput.resolveInclude may return a promise and parseProgram also returns a
+ * promise. true by default.
+ * @param options `defaultParseOptions` by default
+ */
+export function parseProgram<AllowAwait extends boolean = true>(
+	mainInput: ParseInput<AllowAwait>,
+	options?: ParseOptions,
+	allowAwait?: AllowAwait
+): AllowAwait extends true ? Promise<ParseResult> : ParseResult;
 export function parseProgram(
-	mainInput: ParseInput,
-	options: ParseOptions = defaultParseOptions
-): ParseResult {
+	mainInput: ParseInput<any>,
+	options: ParseOptions = defaultParseOptions,
+	allowAwait: boolean = true
+): Promise<ParseResult> | ParseResult {
 	const includedFiles = new Set<string>();
 	/** list of errors */
 	const errors: ParseErrorOrWarning[] = [];
@@ -206,15 +232,53 @@ export function parseProgram(
 	}
 
 	/**
-	 * Parse one library or program from a file. Includes are supported
+	 * Parse one library or program from a file. Includes are supported.
+	 *
+	 * To support runtime switching between async and sync, parseFile and
+	 * parseFileAsync both use parseFileGenerator under the hood
+	 * and only act as event loops for the returned Generator. In parseFile, all
+	 * yields are evaluated to its operand, which allows the function to remain
+	 * synchronous. In parseFileAsync, yields are evaluated to the awaited value
+	 * of the operand, thus making yields in parseFileGenerator equivalent to
+	 * awaits.
 	 */
-	function parseFile(file: ParseInput) {
+	function parseFile(file: ParseInput<any>) {
+		const gen = parseFileGenerator(file);
+		// let yield expressions always evaluate to its operand
+		for (let e = gen.next(); !e.done; e = gen.next(e.value)) {
+			if (e.value instanceof Promise) {
+				throw new Error("Unexpected Promise, async not allowed");
+			}
+		}
+	}
+	async function parseFileAsync(file: ParseInput<any>): Promise<void> {
+		const gen = parseFileGenerator(file);
+		let e = gen.next();
+		while (!e.done) {
+			// pass control to event loop and get result
+			const awaitedVal = await e.value;
+			// continue generator and provide result
+			e = gen.next(awaitedVal);
+		}
+	}
+	/**
+	 * Depending on where this is called, yield corresponds to either just
+	 * return the value (expecting it to not be a promise), or awaiting it if it
+	 * is a promise.
+	 */
+	function* parseFileGenerator(
+		file: ParseInput<any>
+	): Generator<
+		ReturnType<ParseInput<any>["resolveInclude"]>,
+		void,
+		ParseInput<any> | null
+	> {
 		includedFiles.add(file.filename);
 		state.setSource(file.source, null, file.filename);
 		while (state.good()) {
 			const inc = parse_include(state, program, options);
 			if (inc !== null) {
-				const targetFile = file.resolveInclude(inc.filename);
+				const targetFile = yield file.resolveInclude(inc.filename);
 				if (!targetFile) {
 					// the file was not found
 					state.set(inc.position);
@@ -234,7 +298,7 @@ export function parseProgram(
 					};
 
 					// import the file
-					parseFile(targetFile);
+					yield* parseFileGenerator(targetFile);
 
 					// restore the state
 					state.source = backup.source;
@@ -263,10 +327,33 @@ export function parseProgram(
 		parseString(lib_turtle.source, lib_turtle.impl);
 		parseString(lib_canvas.source, lib_canvas.impl);
 		parseString(lib_audio.source, lib_audio.impl);
-
-		// parse the user's source code
 		program.where = state.get();
-		parseFile(mainInput);
+	} catch (e) {
+		handleError(e);
+		return constructResult();
+	}
+
+	if (allowAwait) {
+		return (async () => {
+			try {
+				await parseFileAsync(mainInput);
+				afterParse();
+			} catch (e) {
+				handleError(e);
+			}
+			return constructResult();
+		})();
+	} else {
+		try {
+			parseFile(mainInput);
+			afterParse();
+		} catch (e) {
+			handleError(e);
+		}
+		return constructResult();
+	}
+
+	function afterParse() {
 		program.lines = state.line;
 
 		// append an "end" breakpoint
@@ -285,7 +372,15 @@ export function parseProgram(
 
 		// further passes may follow in the future, e.g., for optimizations
 		// compilerPass("Optimize");
-	} catch (ex: any) {
+	}
+
+	function constructResult() {
+		return errors.length > 0
+			? { program: null, errors }
+			: { program, errors: [] };
+	}
+
+	function handleError(ex: any) {
 		// ignore the actual exception and rely on state.errors instead
 		if (ex.name !== "Parse Error") {
 			// report an internal parser error
@@ -298,10 +393,6 @@ export function parseProgram(
 			});
 		}
 	}
-
-	return errors.length > 0
-		? { program: null, errors }
-		: { program, errors: [] };
 }
 
 /** recursive compiler pass through the syntax tree */


### PR DESCRIPTION
(Also contained in pull request "(v3) Implement file IDs for internal use")

Adds for support for the use of include statements in programs from file storages that can only be accessed asynchronously. Specifically, this pull request allows `ParseInput.resolveInclude` to return a Promise.

Changes since v2:
- Remember promise in `prepareRun()`

Changes since v1:
- Replace Generator-based implementation of `parseFile`/`parseFileAsync` with one asynchronous implementation that supports includes, and the existing `parseString` (which is synchronous but doesn't support includes)
- Split `ParseInput` into `ParseInput` (whose `resolveInclude` is asynchronous) and `ParseInputWithoutIncludes` (that doesn't have a `resolveInclude` function)