### PR TITLE
Update replaceUrl

### DIFF
--- a/src/ide/index.ts
+++ b/src/ide/index.ts
@@ -50,7 +50,7 @@ window.addEventListener("load", async () => {
 	if (gitCode && git_auth_type) {
 		let res;
 		if (git_auth_type == "hub") {
-			replaceUrl(currentUrl.origin);
+			replaceUrl(currentUrl.href.split("?")[0]);
 			try {
 				res = await fetch(
 					`${server_url}/auth-token-exchange?client_id=${client_id_github}&code=${gitCode}&type=hub`,
@@ -62,7 +62,7 @@ window.addEventListener("load", async () => {
 				alert("Error trying to login with GitHub.");
 			}
 		} else if (git_auth_type == "lab") {
-			replaceUrl(currentUrl.origin);
+			replaceUrl(currentUrl.href.split("?")[0]);
 			try {
 				res = await fetch(
 					`${server_url}/auth-token-exchange?client_id=${app_id_gitlab}&code=${gitCode}&type=lab`,


### PR DESCRIPTION
During the OAuth 2.0 authorization process, the temporary code parameter should be removed from the URL.
There was a bug that replaced `https://tglas.github.io/tscript?code=randomString` with `https://tglas.github.io`
The `/tscript/` was missing from the URL, the correct redirect is now `https://tglas.github.io/tscript/`