### PR TITLE
Two fixes concerning namespaces

### DIFF
--- a/src/lang/parser/parse_expression.ts
+++ b/src/lang/parser/parse_expression.ts
@@ -942,7 +942,8 @@ export function parse_expression(
 									if (
 										reference.petype === "variable" &&
 										reference.where.hasOwnProperty("pos") &&
-										op.where.pos < reference.where.pos
+										op.where.totalpos <
+											reference.where.totalpos
 									) {
 										state.error("/name/ne-5", [
 											"expression",

--- a/src/lang/parser/parse_expression.ts
+++ b/src/lang/parser/parse_expression.ts
@@ -1049,7 +1049,7 @@ export function parse_expression(
 									) {
 										state.error("/name/ne-30", [op.name]);
 									} else {
-										ex.petype = "non-value name"; // this name must be qualified further to yield a value
+										op.petype = "non-value name"; // this name must be qualified further to yield a value
 									}
 								}
 							} else {
@@ -1061,9 +1061,9 @@ export function parse_expression(
 						}
 					},
 					passResolveBack: function (state) {
-						if (ex.petype == "non-value name") {
-							state.set(ex.where);
-							state.error("/name/ne-10", [ex.name]);
+						if (op.petype == "non-value name") {
+							state.set(op.where);
+							state.error("/name/ne-10", [op.name]);
 						}
 					},
 				};

--- a/src/lang/tests/lt_source.ts
+++ b/src/lang/tests/lt_source.ts
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-export const lt_source = `
+export const lt_source = String.raw`
 #[file] main.tscript
 ###
 ##

--- a/src/lang/tests/testRunner.ts
+++ b/src/lang/tests/testRunner.ts
@@ -56,15 +56,23 @@ export class TestRunner {
 		let result = new Array();
 
 		// parse the program
-		let parsed: ParseResult;
-		try {
-			parsed = parseProgramFromString(test.code);
-			if (test.parseOnly) {
+		let parsed = parseProgramFromString(test.code);
+
+		if (test.parseOnly) {
+			// report result and return
+			if (parsed.errors.length === 0) {
 				cb.suc(test);
-				return;
+			} else {
+				const msgs = parsed.errors.map((err) => {
+					return ErrorHelper.getLocatedErrorMsg(
+						err.type,
+						err.filename ?? undefined,
+						err.line,
+						err.message
+					);
+				});
+				cb.fail(test, msgs.join("\n"));
 			}
-		} catch (ex) {
-			cb.fail(test, ex);
 			return;
 		}
 

--- a/src/lang/tests/tscript.test.ts
+++ b/src/lang/tests/tscript.test.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from "chai";
+import { assert } from "chai";
 import "mocha";
 import { TestRunner } from "./testRunner";
 import { tests, TscriptTest } from "./tests";
@@ -6,8 +6,8 @@ import { tests, TscriptTest } from "./tests";
 let testcases = tests;
 
 let cb = {
-	suc: function () {},
-	fail: function (ex) {
+	suc: function (_test: TscriptTest) {},
+	fail: function (_test: TscriptTest, ex: string) {
 		assert.fail(ex);
 	},
 };
@@ -31,7 +31,10 @@ describe("tests can fail", () => {
 	it("should fail", async () => {
 		await TestRunner.runTest(
 			failTest,
-			{ suc: cb.fail, fail: cb.suc },
+			{
+				suc: (t) => cb.fail(t, "Test was expected to fail"),
+				fail: cb.suc,
+			},
 			false
 		);
 	});


### PR DESCRIPTION
Fix two bugs with namespaces and fix the lattice craft test.

1. For asserting that the access to a member variable (of a namespace or a static variable of a class) can only be made after that variable is declared, `op.where.pos` was used instead of `op.where.totalpos`, which  breaks when using includes. For example, if these are two files, File1 can't be executed (even though it can when removing the semicolons from line 1 of File2):

File1:
```
include "File2";
print(ns.v);
```
File2:
```
namespace ns {;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
	var v;
}
```

2.  In parse_expression.ts, `ex` was still used in some places in anonymous functions (`passResolve` and `passResolveBack`) even though due to how scoping works, the value of `ex` will always be the last member access expression (from the last iteration of the inner while loop). This led in particular to the following program not being accepted:
```
namespace A {
	namespace B {
		function func(){}
	}
}

A.B.func();
```

The second bug also broke lattice craft. However, the test that checks that lattice craft can be parsed was also broken. The last commit fixes the test.