### PR TITLE
Only allow clone when project is selected

### DIFF
--- a/src/ide/git_logic.ts
+++ b/src/ide/git_logic.ts
@@ -49,7 +49,7 @@ export async function setGitConfig() {
  */
 export async function gitClone(url: string): Promise<boolean> {
 	const projName = getCurrentProject() || "";
-	if(projName === "") {
+	if (projName === "") {
 		addMessage("error", "No project selected.");
 		return false;
 	}


### PR DESCRIPTION
Previously, users could clone without selecting / creating a project, resulting in the contents of the git repo being listed in the project browser instead of the filetree.